### PR TITLE
实现HFP蓝牙麦克风支持，支持眼镜麦克风远距离语音输入

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
     <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28"

--- a/android/app/src/main/java/com/turbometa/rayban/services/GeminiLiveService.kt
+++ b/android/app/src/main/java/com/turbometa/rayban/services/GeminiLiveService.kt
@@ -12,6 +12,7 @@ import android.util.Base64
 import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.turbometa.rayban.managers.BluetoothAudioManager
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -28,7 +29,8 @@ import java.util.concurrent.TimeUnit
 class GeminiLiveService(
     private val apiKey: String,
     private val model: String = "gemini-2.0-flash-exp",
-    private val outputLanguage: String = "zh-CN"
+    private val outputLanguage: String = "zh-CN",
+    private val context: Context? = null
 ) {
     companion object {
         private const val TAG = "GeminiLiveService"
@@ -85,6 +87,17 @@ class GeminiLiveService(
     private var audioChunkCount = 0
     private val minChunksBeforePlay = 2
     private var hasStartedPlaying = false
+
+    // Bluetooth Audio Manager
+    private var bluetoothAudioManager: BluetoothAudioManager? = null
+    private var currentAudioSource = BluetoothAudioManager.AudioSource.PHONE_MIC
+
+    init {
+        // 初始化蓝牙音频管理器
+        context?.let {
+            bluetoothAudioManager = BluetoothAudioManager(it)
+        }
+    }
 
     private val client = OkHttpClient.Builder()
         .readTimeout(0, TimeUnit.MILLISECONDS)
@@ -145,7 +158,26 @@ class GeminiLiveService(
         _isRecording.value = false
         _isSpeaking.value = false
         isSessionConfigured = false
+        bluetoothAudioManager?.cleanup()
         scope.cancel()
+    }
+
+    /**
+     * 根据当前音频源获取输入采样率
+     */
+    private fun getInputSampleRate(): Int {
+        // Gemini输入固定使用16kHz，与HFP兼容
+        return INPUT_SAMPLE_RATE
+    }
+
+    /**
+     * 根据当前音频源获取AudioSource
+     */
+    private fun getAudioSource(): Int {
+        return when (currentAudioSource) {
+            BluetoothAudioManager.AudioSource.BLUETOOTH_MIC -> MediaRecorder.AudioSource.VOICE_COMMUNICATION
+            BluetoothAudioManager.AudioSource.PHONE_MIC -> MediaRecorder.AudioSource.MIC
+        }
     }
 
     // MARK: - Session Configuration
@@ -228,9 +260,10 @@ class GeminiLiveService(
         try {
             Log.d(TAG, "Starting recording")
 
+            val audioSource = getAudioSource()
             val bufferSize = AudioRecord.getMinBufferSize(INPUT_SAMPLE_RATE, CHANNEL_CONFIG, AUDIO_FORMAT)
             audioRecord = AudioRecord(
-                MediaRecorder.AudioSource.MIC,
+                audioSource,
                 INPUT_SAMPLE_RATE,
                 CHANNEL_CONFIG,
                 AUDIO_FORMAT,
@@ -276,6 +309,32 @@ class GeminiLiveService(
         audioRecord?.release()
         audioRecord = null
         hasAudioBeenSent = false
+    }
+
+    /**
+     * 切换音频源
+     * @param source 目标音频源
+     */
+    fun switchAudioSource(source: BluetoothAudioManager.AudioSource) {
+        if (currentAudioSource == source) return
+
+        val wasRecording = _isRecording.value
+
+        // 停止当前录音
+        if (wasRecording) {
+            stopRecording()
+        }
+
+        // 切换音频路由
+        bluetoothAudioManager?.switchAudioSource(source)
+        currentAudioSource = source
+
+        // 如果之前在录音，重新启动
+        if (wasRecording) {
+            startRecording()
+        }
+
+        Log.d(TAG, "音频源已切换到: $source")
     }
 
     fun updateVideoFrame(frame: Bitmap) {
@@ -480,9 +539,15 @@ class GeminiLiveService(
                 AudioFormat.ENCODING_PCM_16BIT
             )
 
-            // 使用 AudioAttributes 替代已弃用的 STREAM_MUSIC（兼容性更好）
+            // 根据音频源选择不同的AudioAttributes
             val audioAttributes = AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setUsage(
+                    if (currentAudioSource == BluetoothAudioManager.AudioSource.BLUETOOTH_MIC) {
+                        AudioAttributes.USAGE_VOICE_COMMUNICATION
+                    } else {
+                        AudioAttributes.USAGE_MEDIA
+                    }
+                )
                 .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                 .build()
 

--- a/android/app/src/main/java/com/turbometa/rayban/services/OmniRealtimeService.kt
+++ b/android/app/src/main/java/com/turbometa/rayban/services/OmniRealtimeService.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.turbometa.rayban.managers.AlibabaEndpoint
+import com.turbometa.rayban.managers.BluetoothAudioManager
 import com.turbometa.rayban.managers.LiveAIModeManager
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -84,6 +85,17 @@ class OmniRealtimeService(
     private val gson = Gson()
     private var scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
+    // Bluetooth Audio Manager
+    private var bluetoothAudioManager: BluetoothAudioManager? = null
+    private var currentAudioSource = BluetoothAudioManager.AudioSource.PHONE_MIC
+
+    init {
+        // 初始化蓝牙音频管理器
+        context?.let {
+            bluetoothAudioManager = BluetoothAudioManager(it)
+        }
+    }
+
     private var pendingImageFrame: Bitmap? = null
     private var lastImageSentTime = 0L
     private val imageSendIntervalMs = 500L  // 发送图片的间隔（毫秒）
@@ -141,17 +153,40 @@ class OmniRealtimeService(
         _isConnected.value = false
         _isRecording.value = false
         _isSpeaking.value = false
+        bluetoothAudioManager?.cleanup()
         scope.cancel()
+    }
+
+    /**
+     * 根据当前音频源获取采样率
+     */
+    private fun getSampleRate(): Int {
+        return when (currentAudioSource) {
+            BluetoothAudioManager.AudioSource.BLUETOOTH_MIC -> 16000  // HFP标准
+            BluetoothAudioManager.AudioSource.PHONE_MIC -> SAMPLE_RATE  // 24000
+        }
+    }
+
+    /**
+     * 根据当前音频源获取AudioSource
+     */
+    private fun getAudioSource(): Int {
+        return when (currentAudioSource) {
+            BluetoothAudioManager.AudioSource.BLUETOOTH_MIC -> MediaRecorder.AudioSource.VOICE_COMMUNICATION
+            BluetoothAudioManager.AudioSource.PHONE_MIC -> MediaRecorder.AudioSource.MIC
+        }
     }
 
     fun startRecording() {
         if (_isRecording.value) return
 
         try {
-            val bufferSize = AudioRecord.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, AUDIO_FORMAT)
+            val sampleRate = getSampleRate()
+            val audioSource = getAudioSource()
+            val bufferSize = AudioRecord.getMinBufferSize(sampleRate, CHANNEL_CONFIG, AUDIO_FORMAT)
             audioRecord = AudioRecord(
-                MediaRecorder.AudioSource.MIC,
-                SAMPLE_RATE,
+                audioSource,
+                sampleRate,
                 CHANNEL_CONFIG,
                 AUDIO_FORMAT,
                 bufferSize * 2
@@ -190,6 +225,32 @@ class OmniRealtimeService(
         audioRecord?.stop()
         audioRecord?.release()
         audioRecord = null
+    }
+
+    /**
+     * 切换音频源
+     * @param source 目标音频源
+     */
+    fun switchAudioSource(source: BluetoothAudioManager.AudioSource) {
+        if (currentAudioSource == source) return
+
+        val wasRecording = _isRecording.value
+
+        // 停止当前录音
+        if (wasRecording) {
+            stopRecording()
+        }
+
+        // 切换音频路由
+        bluetoothAudioManager?.switchAudioSource(source)
+        currentAudioSource = source
+
+        // 如果之前在录音，重新启动
+        if (wasRecording) {
+            startRecording()
+        }
+
+        Log.d(TAG, "音频源已切换到: $source")
     }
 
     fun updateVideoFrame(frame: Bitmap) {
@@ -362,15 +423,22 @@ class OmniRealtimeService(
 
     private fun startAudioPlayback() {
         if (audioTrack == null) {
+            // 输出采样率固定使用AI返回的采样率（24kHz）
             val bufferSize = AudioTrack.getMinBufferSize(
                 SAMPLE_RATE,
                 AudioFormat.CHANNEL_OUT_MONO,
                 AudioFormat.ENCODING_PCM_16BIT
             )
 
-            // 使用 AudioAttributes 替代已弃用的 STREAM_MUSIC（兼容性更好）
+            // 根据音频源选择不同的AudioAttributes
             val audioAttributes = AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setUsage(
+                    if (currentAudioSource == BluetoothAudioManager.AudioSource.BLUETOOTH_MIC) {
+                        AudioAttributes.USAGE_VOICE_COMMUNICATION
+                    } else {
+                        AudioAttributes.USAGE_MEDIA
+                    }
+                )
                 .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                 .build()
 

--- a/android/app/src/main/java/com/turbometa/rayban/ui/screens/LiveAIScreen.kt
+++ b/android/app/src/main/java/com/turbometa/rayban/ui/screens/LiveAIScreen.kt
@@ -36,6 +36,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.meta.wearable.dat.core.types.Permission
 import com.meta.wearable.dat.core.types.PermissionStatus
 import com.turbometa.rayban.R
+import com.turbometa.rayban.managers.BluetoothAudioManager
 import com.turbometa.rayban.models.ConversationMessage
 import com.turbometa.rayban.models.MessageRole
 import com.turbometa.rayban.ui.components.*
@@ -58,6 +59,11 @@ fun LiveAIScreen(
     val isConnected by viewModel.isConnected.collectAsState()
     val isRecording by viewModel.isRecording.collectAsState()
     val isSpeaking by viewModel.isSpeaking.collectAsState()
+
+    // Audio source state
+    val currentAudioSource by viewModel.currentAudioSource.collectAsState()
+    val isBluetoothScoConnected by viewModel.isBluetoothScoConnected.collectAsState()
+    val isBluetoothScoAvailable by viewModel.isBluetoothScoAvailable.collectAsState()
 
     // Wearables state
     val currentFrame by wearablesViewModel.currentFrame.collectAsState()
@@ -206,6 +212,15 @@ fun LiveAIScreen(
                         modifier = Modifier.padding(AppSpacing.medium)
                     )
                 }
+
+                // Audio source toggle
+                AudioSourceToggle(
+                    currentSource = currentAudioSource,
+                    isBluetoothAvailable = isBluetoothScoAvailable,
+                    onSourceChange = { source ->
+                        viewModel.switchAudioSource(source)
+                    }
+                )
 
                 // Messages list
                 LazyColumn(
@@ -605,5 +620,52 @@ private fun getInstructionText(
         state == OmniRealtimeViewModel.ViewState.Processing -> stringResource(R.string.processing_response)
         state == OmniRealtimeViewModel.ViewState.Speaking -> stringResource(R.string.ai_speaking)
         else -> stringResource(R.string.tap_to_speak)
+    }
+}
+
+/**
+ * 音频源切换组件
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AudioSourceToggle(
+    currentSource: BluetoothAudioManager.AudioSource,
+    isBluetoothAvailable: Boolean,
+    onSourceChange: (BluetoothAudioManager.AudioSource) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        // 手机麦克风按钮
+        FilterChip(
+            selected = currentSource == BluetoothAudioManager.AudioSource.PHONE_MIC,
+            onClick = { onSourceChange(BluetoothAudioManager.AudioSource.PHONE_MIC) },
+            label = { Text("手机麦克风") },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.PhoneAndroid,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        )
+
+        // 眼镜麦克风按钮
+        FilterChip(
+            selected = currentSource == BluetoothAudioManager.AudioSource.BLUETOOTH_MIC,
+            onClick = { onSourceChange(BluetoothAudioManager.AudioSource.BLUETOOTH_MIC) },
+            label = { Text("眼镜麦克风") },
+            enabled = isBluetoothAvailable,
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Bluetooth,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        )
     }
 }

--- a/android/app/src/main/java/com/turbometa/rayban/viewmodels/OmniRealtimeViewModel.kt
+++ b/android/app/src/main/java/com/turbometa/rayban/viewmodels/OmniRealtimeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.turbometa.rayban.data.ConversationStorage
 import com.turbometa.rayban.managers.APIProviderManager
+import com.turbometa.rayban.managers.BluetoothAudioManager
 import com.turbometa.rayban.managers.LiveAIProvider
 import com.turbometa.rayban.models.ConversationMessage
 import com.turbometa.rayban.models.ConversationRecord
@@ -34,6 +35,9 @@ class OmniRealtimeViewModel(application: Application) : AndroidViewModel(applica
     private val apiKeyManager = APIKeyManager.getInstance(application)
     private val providerManager = APIProviderManager.getInstance(application)
     private val conversationStorage = ConversationStorage.getInstance(application)
+
+    // Bluetooth Audio Manager
+    private val bluetoothAudioManager = BluetoothAudioManager(application)
 
     // Services
     private var omniService: OmniRealtimeService? = null
@@ -77,6 +81,11 @@ class OmniRealtimeViewModel(application: Application) : AndroidViewModel(applica
 
     private val _isSpeaking = MutableStateFlow(false)
     val isSpeaking: StateFlow<Boolean> = _isSpeaking.asStateFlow()
+
+    // Audio source state
+    val currentAudioSource: StateFlow<BluetoothAudioManager.AudioSource> = bluetoothAudioManager.currentAudioSource
+    val isBluetoothScoConnected: StateFlow<Boolean> = bluetoothAudioManager.isBluetoothScoConnected
+    val isBluetoothScoAvailable: StateFlow<Boolean> = bluetoothAudioManager.isBluetoothScoAvailable
 
     private var currentSessionId: String = UUID.randomUUID().toString()
     private var pendingVideoFrame: Bitmap? = null
@@ -324,6 +333,22 @@ class OmniRealtimeViewModel(application: Application) : AndroidViewModel(applica
         }
         if (_viewState.value == ViewState.Recording) {
             _viewState.value = ViewState.Processing
+        }
+    }
+
+    /**
+     * 切换音频源（手机麦克风 / 眼镜麦克风）
+     */
+    fun switchAudioSource(source: BluetoothAudioManager.AudioSource) {
+        Log.d(TAG, "切换音频源到: $source")
+
+        // 切换蓝牙音频管理器的音频源
+        bluetoothAudioManager.switchAudioSource(source)
+
+        // 通知当前活动的Service切换音频源
+        when (_currentProvider.value) {
+            LiveAIProvider.ALIBABA -> omniService?.switchAudioSource(source)
+            LiveAIProvider.GOOGLE -> geminiService?.switchAudioSource(source)
         }
     }
 


### PR DESCRIPTION
##功能概述

  为TurboMeta添加完整的HFP蓝牙麦克风支持，允许用户使用Ray-Ban Meta眼镜麦克风进行远距离语音输入，无需靠近手机。

  ## 主要改动

  ### 新增功能
  - ✅ 新增 `BluetoothAudioManager` 类，统一管理蓝牙SCO连接
  - ✅ 支持手机麦克风和眼镜麦克风动态切换
  - ✅ 添加音频源切换UI控件（FilterChip）
  - ✅ 自动检测蓝牙SCO可用性，智能启用/禁用眼镜麦克风按钮
  - ✅蓝牙断开时自动降级到手机麦克风

  ## 技术实现

  ### 核心架构
  - 使用HFP/SCO协议实现双向音频传输
  - 输入采样率根据音频源动态调整（手机24kHz，眼镜16kHz）
  - 输出采样率固定使用AI返回的24kHz，确保音质一致

  ### 兼容性
  - ✅ 支持Android 10+所有版本
  - ✅ 处理Android 12+新API（`setCommunicationDevice`）
  - ✅ 兼容阿里云Omni和Google Gemini两个AI服务
  - ✅ 保留手机麦克风作为默认和备用方案

  ### 修改的文件
  - `BluetoothAudioManager.kt` - 新增蓝牙音频管理器
  - `OmniRealtimeService.kt` - 集成蓝牙音频支持
  - `GeminiLiveService.kt` - 集成蓝牙音频支持
  - `OmniRealtimeViewModel.kt` - 添加音频源状态管理
  - `LiveAIScreen.kt` - 添加音频源切换UI
  - `AndroidManifest.xml` - 添加蓝牙权限

  ## 测试情况

  - [x] 手机麦克风模式正常工作
  - [x] 眼镜麦克风模式正常工作
  - [x] 两种模式间平滑切换
  - [x] 蓝牙断开自动降级
  - [x] AI声音在两种模式下保持一致
  - [x] 按钮状态正确响应蓝牙连接状态

  ## 使用说明

  1. 连接Ray-Ban Meta眼镜
  2. 进入Live AI界面
  3. 点击顶部的音频源切换按钮
  4. 选择"眼镜麦克风"即可使用远距离语音输入

  ## 注意事项

  - 眼镜麦克风使用HFP协议，音质略低于手机麦克风（A2DP），这是协议特性
  - 蓝牙SCO连接可能需要2-3秒建立
  - 如果眼镜未连接，眼镜麦克风按钮会自动禁用