### PR TITLE
[codex] Add AIHubMix, Live AI, and RTMP streaming updates

### DIFF
--- a/CameraAccess/Managers/APIProviderManager.swift
+++ b/CameraAccess/Managers/APIProviderManager.swift
@@ -1,6 +1,6 @@
 /*
  * API Provider Manager
- * 管理不同的 API 提供商 (阿里云 Dashscope / OpenRouter)
+ * 管理不同的 API 提供商 (阿里云 Dashscope / OpenRouter / AIHubMix)
  */
 
 import Foundation
@@ -39,11 +39,13 @@ enum AlibabaEndpoint: String, CaseIterable, Codable {
 enum APIProvider: String, CaseIterable, Codable {
     case alibaba = "alibaba"
     case openrouter = "openrouter"
+    case aihubmix = "aihubmix"
 
     var displayName: String {
         switch self {
         case .alibaba: return "阿里云 Dashscope"
         case .openrouter: return "OpenRouter"
+        case .aihubmix: return "AIHubMix"
         }
     }
 
@@ -51,6 +53,7 @@ enum APIProvider: String, CaseIterable, Codable {
         switch self {
         case .alibaba: return endpoint.baseURL
         case .openrouter: return "https://openrouter.ai/api/v1"
+        case .aihubmix: return "https://aihubmix.com/v1"
         }
     }
 
@@ -62,6 +65,7 @@ enum APIProvider: String, CaseIterable, Codable {
         switch self {
         case .alibaba: return "qwen3-vl-plus"
         case .openrouter: return "google/gemini-3-flash-preview"
+        case .aihubmix: return "gpt-5.4"
         }
     }
 
@@ -69,6 +73,7 @@ enum APIProvider: String, CaseIterable, Codable {
         switch self {
         case .alibaba: return "https://help.aliyun.com/zh/model-studio/get-api-key"
         case .openrouter: return "https://openrouter.ai/keys"
+        case .aihubmix: return "https://aihubmix.com/token"
         }
     }
 
@@ -93,7 +98,21 @@ enum LiveAIProvider: String, CaseIterable, Codable {
     var defaultModel: String {
         switch self {
         case .alibaba: return "qwen3-omni-flash-realtime"
-        case .google: return "gemini-2.0-flash-exp"
+        case .google: return "gemini-3.1-flash-live-preview"
+        }
+    }
+
+    var availableModels: [(id: String, name: String)] {
+        switch self {
+        case .alibaba:
+            return [
+                ("qwen3-omni-flash-realtime", "qwen3-omni-flash-realtime")
+            ]
+        case .google:
+            return [
+                ("gemini-3.1-flash-live-preview", "Gemini 3.1 Flash Live Preview"),
+                ("gemini-2.5-flash-native-audio-preview-12-2025", "Gemini 2.5 Flash Native Audio Preview")
+            ]
         }
     }
 
@@ -252,7 +271,11 @@ class APIProviderManager: ObservableObject {
         self.liveAIProvider = liveProvider
 
         let savedLiveAIModel = UserDefaults.standard.string(forKey: liveAIModelKey)
-        self.liveAIModel = savedLiveAIModel ?? liveProvider.defaultModel
+        if liveProvider == .google, savedLiveAIModel == "gemini-2.0-flash-exp" {
+            self.liveAIModel = liveProvider.defaultModel
+        } else {
+            self.liveAIModel = savedLiveAIModel ?? liveProvider.defaultModel
+        }
     }
 
     // MARK: - Live AI Configuration
@@ -385,6 +408,14 @@ extension APIProviderManager {
         case .google:
             return APIKeyManager.shared.getGoogleAPIKey() ?? ""
         }
+    }
+
+    nonisolated static var staticLiveAIModel: String {
+        let savedModel = UserDefaults.standard.string(forKey: "liveai_model")
+        if staticLiveAIProvider == .google, savedModel == "gemini-2.0-flash-exp" {
+            return staticLiveAIProvider.defaultModel
+        }
+        return savedModel ?? staticLiveAIProvider.defaultModel
     }
 
     nonisolated static var staticCurrentModel: String {

--- a/CameraAccess/Managers/LiveAIManager.swift
+++ b/CameraAccess/Managers/LiveAIManager.swift
@@ -179,7 +179,7 @@ class LiveAIManager: ObservableObject {
             omniService = OmniRealtimeService(apiKey: apiKey)
             setupOmniCallbacks()
         case .google:
-            geminiService = GeminiLiveService(apiKey: apiKey)
+            geminiService = GeminiLiveService(apiKey: apiKey, model: APIProviderManager.staticLiveAIModel)
             setupGeminiCallbacks()
         }
     }
@@ -400,13 +400,13 @@ class LiveAIManager: ObservableObject {
         case .alibaba:
             aiModel = "qwen3-omni-flash-realtime"
         case .google:
-            aiModel = "gemini-2.0-flash-exp"
+            aiModel = APIProviderManager.staticLiveAIModel
         }
 
         let record = ConversationRecord(
             messages: conversationHistory,
             aiModel: aiModel,
-            language: "zh-CN"
+            language: "auto-bilingual"
         )
 
         ConversationStorage.shared.saveConversation(record)

--- a/CameraAccess/Managers/LiveAIModeManager.swift
+++ b/CameraAccess/Managers/LiveAIModeManager.swift
@@ -63,7 +63,7 @@ class LiveAIModeManager: ObservableObject {
         if let savedLanguage = userDefaults.string(forKey: translateTargetLanguageKey) {
             self.translateTargetLanguage = savedLanguage
         } else {
-            self.translateTargetLanguage = LanguageManager.staticApiLanguageCode
+            self.translateTargetLanguage = LanguageManager.staticIsChinese ? "zh-CN" : "en-US"
         }
     }
 
@@ -71,26 +71,30 @@ class LiveAIModeManager: ObservableObject {
 
     /// 获取当前模式的完整系统提示词
     func getSystemPrompt() -> String {
+        let prompt: String
         switch currentMode {
         case .custom:
-            return customPrompt
+            prompt = customPrompt
         case .translate:
-            return getTranslatePrompt()
+            prompt = getTranslatePrompt()
         default:
-            return currentMode.systemPrompt
+            prompt = currentMode.systemPrompt
         }
+        return promptWithBilingualPolicy(prompt)
     }
 
     /// 获取指定模式的系统提示词
     func getSystemPrompt(for mode: LiveAIMode) -> String {
+        let prompt: String
         switch mode {
         case .custom:
-            return customPrompt
+            prompt = customPrompt
         case .translate:
-            return getTranslatePrompt()
+            prompt = getTranslatePrompt()
         default:
-            return mode.systemPrompt
+            prompt = mode.systemPrompt
         }
+        return promptWithBilingualPolicy(prompt)
     }
 
     /// 获取翻译模式的提示词（包含目标语言）
@@ -98,6 +102,20 @@ class LiveAIModeManager: ObservableObject {
         let targetLanguageName = Self.supportedLanguages.first { $0.code == translateTargetLanguage }?.name ?? "中文"
         let basePrompt = "prompt.liveai.translate".localized
         return basePrompt.replacingOccurrences(of: "{LANGUAGE}", with: targetLanguageName)
+    }
+
+    private func promptWithBilingualPolicy(_ prompt: String) -> String {
+        let policy = """
+
+        Live AI language policy:
+        - Support both Chinese and English in the same conversation.
+        - Detect the user's spoken language every turn.
+        - If the user speaks Chinese, reply in Chinese.
+        - If the user speaks English, reply in English.
+        - If the user mixes Chinese and English, reply naturally with the same mixed-language style.
+        - Do not force Chinese or English unless the user explicitly asks for a specific language.
+        """
+        return prompt + policy
     }
 
     // MARK: - Mode Management

--- a/CameraAccess/Services/GeminiLiveService.swift
+++ b/CameraAccess/Services/GeminiLiveService.swift
@@ -1,7 +1,7 @@
 /*
  * Gemini Live WebSocket Service
  * Provides real-time audio chat with Google Gemini AI
- * Uses gemini-2.0-flash-exp model for real-time audio conversation
+ * Uses Gemini Live models for real-time audio conversation
  */
 
 import Foundation
@@ -54,10 +54,11 @@ class GeminiLiveService: NSObject {
     private var isRecording = false
     private var hasAudioBeenSent = false
     private var isSessionConfigured = false
+    private var isDisconnecting = false
 
     init(apiKey: String, model: String? = nil) {
         self.apiKey = apiKey
-        self.model = model ?? "gemini-2.0-flash-exp"
+        self.model = model ?? LiveAIProvider.google.defaultModel
         super.init()
         setupAudioEngine()
     }
@@ -88,7 +89,7 @@ class GeminiLiveService: NSObject {
     private func configureAudioSession() {
         do {
             let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker])
+            try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker])
             try audioSession.setActive(true, options: [.notifyOthersOnDeactivation])
         } catch {
             print("⚠️ [Gemini] Audio session 配置失败: \(error)")
@@ -126,6 +127,7 @@ class GeminiLiveService: NSObject {
         let urlString = "\(baseURL)?key=\(apiKey)"
 
         print("🔌 [Gemini] 准备连接 WebSocket")
+        isDisconnecting = false
 
         guard let url = URL(string: urlString) else {
             print("❌ [Gemini] 无效的 URL")
@@ -145,6 +147,7 @@ class GeminiLiveService: NSObject {
 
     func disconnect() {
         print("🔌 [Gemini] 断开 WebSocket 连接")
+        isDisconnecting = true
         webSocket?.cancel(with: .goingAway, reason: nil)
         webSocket = nil
         urlSession?.invalidateAndCancel()
@@ -166,17 +169,19 @@ class GeminiLiveService: NSObject {
         let setupMessage: [String: Any] = [
             "setup": [
                 "model": "models/\(model)",
-                "generation_config": [
-                    "response_modalities": ["AUDIO"],
-                    "speech_config": [
-                        "voice_config": [
-                            "prebuilt_voice_config": [
-                                "voice_name": "Aoede"  // Gemini voice options: Aoede, Charon, Fenrir, Kore, Puck
+                "generationConfig": [
+                    "responseModalities": ["AUDIO"],
+                    "speechConfig": [
+                        "voiceConfig": [
+                            "prebuiltVoiceConfig": [
+                                "voiceName": "Aoede"
                             ]
                         ]
                     ]
                 ],
-                "system_instruction": [
+                "inputAudioTranscription": [:],
+                "outputAudioTranscription": [:],
+                "systemInstruction": [
                     "parts": [
                         ["text": instructions]
                     ]
@@ -196,10 +201,9 @@ class GeminiLiveService: NSObject {
         do {
             print("🎤 [Gemini] 开始录音")
 
-            let audioSession = AVAudioSession.sharedInstance()
-            switch audioSession.recordPermission {
+            switch AVAudioApplication.shared.recordPermission {
             case .undetermined:
-                audioSession.requestRecordPermission { [weak self] granted in
+                AVAudioApplication.requestRecordPermission { [weak self] granted in
                     DispatchQueue.main.async {
                         if granted {
                             self?.startRecording()
@@ -335,12 +339,10 @@ class GeminiLiveService: NSObject {
     private func sendRealtimeInput(audioData: String) {
         // Gemini Live realtime input format
         let message: [String: Any] = [
-            "realtime_input": [
-                "media_chunks": [
-                    [
-                        "mime_type": "audio/pcm;rate=16000",
-                        "data": audioData
-                    ]
+            "realtimeInput": [
+                "audio": [
+                    "mimeType": "audio/pcm;rate=16000",
+                    "data": audioData
                 ]
             ]
         ]
@@ -357,12 +359,10 @@ class GeminiLiveService: NSObject {
         print("📸 [Gemini] 发送图片: \(imageData.count) bytes")
 
         let message: [String: Any] = [
-            "realtime_input": [
-                "media_chunks": [
-                    [
-                        "mime_type": "image/jpeg",
-                        "data": base64Image
-                    ]
+            "realtimeInput": [
+                "video": [
+                    "mimeType": "image/jpeg",
+                    "data": base64Image
                 ]
             ]
         ]
@@ -380,7 +380,8 @@ class GeminiLiveService: NSObject {
 
             case .failure(let error):
                 print("❌ [Gemini] 接收消息失败: \(error.localizedDescription)")
-                self?.onError?("Receive error: \(error.localizedDescription)")
+                guard self?.isDisconnecting != true else { return }
+                self?.onError?("Gemini Live 连接失败：\(error.localizedDescription)")
             }
         }
     }
@@ -593,5 +594,9 @@ extension GeminiLiveService: URLSessionWebSocketDelegate {
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
         let reasonString = reason.flatMap { String(data: $0, encoding: .utf8) } ?? "unknown"
         print("🔌 [Gemini] WebSocket 已断开, closeCode: \(closeCode.rawValue), reason: \(reasonString)")
+        guard !isDisconnecting, !isSessionConfigured else { return }
+        DispatchQueue.main.async {
+            self.onError?("Gemini Live 未完成连接。请检查 Google API Key 是否启用 Gemini API、账号地区是否支持 Live API，以及模型是否可用。closeCode=\(closeCode.rawValue), reason=\(reasonString)")
+        }
     }
 }

--- a/CameraAccess/Services/LiveTranslateService.swift
+++ b/CameraAccess/Services/LiveTranslateService.swift
@@ -18,9 +18,8 @@ class LiveTranslateService: NSObject {
     // Configuration
     private let apiKey: String
     private let model = "qwen3-livetranslate-flash-realtime"
-    // 根据用户设置的区域动态获取 WebSocket URL
     private var baseURL: String {
-        return APIProviderManager.staticLiveAIWebsocketURL
+        return APIProviderManager.staticAlibabaEndpoint.websocketURL
     }
 
     // Audio Engine (for recording)
@@ -59,6 +58,9 @@ class LiveTranslateService: NSObject {
 
     // State
     private var isRecording = false
+    private var isSocketOpen = false
+    private var isSessionReady = false
+    private var isDisconnecting = false
     private var eventIdCounter = 0
 
     // Image sending
@@ -137,6 +139,9 @@ class LiveTranslateService: NSObject {
         urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: OperationQueue())
 
         webSocket = urlSession?.webSocketTask(with: request)
+        isDisconnecting = false
+        isSocketOpen = false
+        isSessionReady = false
         webSocket?.resume()
 
         print("🔌 [Translate] WebSocket 任务已启动")
@@ -145,12 +150,15 @@ class LiveTranslateService: NSObject {
 
     func disconnect() {
         print("🔌 [Translate] 断开 WebSocket 连接")
+        isDisconnecting = true
         webSocket?.cancel(with: .goingAway, reason: nil)
         webSocket = nil
         urlSession?.invalidateAndCancel()
         urlSession = nil
         stopRecording()
         stopPlaybackEngine()
+        isSocketOpen = false
+        isSessionReady = false
     }
 
     // MARK: - Configuration
@@ -167,7 +175,7 @@ class LiveTranslateService: NSObject {
         self.audioOutputEnabled = audioEnabled
 
         // 如果已连接，重新配置会话
-        if webSocket != nil {
+        if isSocketOpen {
             configureSession()
         }
     }
@@ -209,6 +217,10 @@ class LiveTranslateService: NSObject {
 
     func startRecording(usePhoneMic: Bool = false) {
         guard !isRecording else { return }
+        guard isSessionReady else {
+            onError?("翻译服务尚未连接完成，请稍后再试")
+            return
+        }
 
         do {
             print("🎤 [Translate] 开始录音, 使用\(usePhoneMic ? "iPhone" : "蓝牙")麦克风")
@@ -233,7 +245,7 @@ class LiveTranslateService: NSObject {
                 try audioSession.setCategory(
                     .playAndRecord,
                     mode: .default,
-                    options: [.allowBluetooth, .defaultToSpeaker]
+                    options: [.allowBluetoothHFP, .defaultToSpeaker]
                 )
                 print("🎙️ [Translate] 使用蓝牙麦克风（翻译自己）")
             }
@@ -281,7 +293,7 @@ class LiveTranslateService: NSObject {
     }
 
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer) {
-        guard let floatChannelData = buffer.floatChannelData else { return }
+        guard buffer.floatChannelData != nil else { return }
 
         let inputSampleRate = buffer.format.sampleRate
 
@@ -365,6 +377,8 @@ class LiveTranslateService: NSObject {
     // MARK: - Image Sending
 
     func sendImageFrame(_ image: UIImage) {
+        guard isSessionReady else { return }
+
         // 限制发送频率：每0.5秒最多一张
         let now = Date()
         if let lastTime = lastImageSendTime, now.timeIntervalSince(lastTime) < imageInterval {
@@ -397,6 +411,11 @@ class LiveTranslateService: NSObject {
     // MARK: - Send Events
 
     private func sendEvent(_ event: [String: Any]) {
+        guard isSocketOpen else {
+            print("⚠️ [Translate] WebSocket 尚未连接，跳过发送事件")
+            return
+        }
+
         guard let jsonData = try? JSONSerialization.data(withJSONObject: event),
               let jsonString = String(data: jsonData, encoding: .utf8) else {
             print("❌ [Translate] 无法序列化事件")
@@ -439,6 +458,7 @@ class LiveTranslateService: NSObject {
 
             case .failure(let error):
                 print("❌ [Translate] 接收消息失败: \(error.localizedDescription)")
+                guard self?.isDisconnecting != true else { return }
                 self?.onError?("Receive error: \(error.localizedDescription)")
             }
         }
@@ -475,6 +495,7 @@ class LiveTranslateService: NSObject {
             case TranslateServerEvent.sessionCreated.rawValue,
                  TranslateServerEvent.sessionUpdated.rawValue:
                 print("✅ [Translate] 会话已建立")
+                self.isSessionReady = true
                 self.onConnected?()
 
             case TranslateServerEvent.responseAudioTranscriptText.rawValue:
@@ -610,6 +631,7 @@ extension LiveTranslateService: URLSessionWebSocketDelegate {
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
         print("✅ [Translate] WebSocket 连接已建立")
         DispatchQueue.main.async {
+            self.isSocketOpen = true
             self.configureSession()
         }
     }
@@ -617,5 +639,11 @@ extension LiveTranslateService: URLSessionWebSocketDelegate {
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
         let reasonString = reason.flatMap { String(data: $0, encoding: .utf8) } ?? "unknown"
         print("🔌 [Translate] WebSocket 已断开, closeCode: \(closeCode.rawValue), reason: \(reasonString)")
+        DispatchQueue.main.async {
+            self.isSocketOpen = false
+            self.isSessionReady = false
+            guard !self.isDisconnecting else { return }
+            self.onError?("翻译服务连接断开：closeCode=\(closeCode.rawValue), reason=\(reasonString)")
+        }
     }
 }

--- a/CameraAccess/Services/RTMPStreamingService.swift
+++ b/CameraAccess/Services/RTMPStreamingService.swift
@@ -26,6 +26,25 @@ enum RTMPStreamingState: Sendable {
     case error(String)
 }
 
+enum RTMPVideoEncodingMode: String, CaseIterable, Sendable {
+    case h264
+    case hevc
+
+    var displayName: String {
+        switch self {
+        case .h264: return "rtmp.codec.h264".localized
+        case .hevc: return "rtmp.codec.hevc".localized
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .h264: return "rtmp.codec.h264.desc".localized
+        case .hevc: return "rtmp.codec.hevc.desc".localized
+        }
+    }
+}
+
 // MARK: - Streaming Stats
 
 struct RTMPStreamingStats: Sendable {
@@ -41,7 +60,7 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
 
     // MARK: - Constants
 
-    private static let defaultBitrate: Int = 2_000_000 // 2 Mbps
+    private static let defaultBitrate: Int = 6_000_000 // 6 Mbps
     private static let defaultFPS: Int = 24
 
     // MARK: - Properties
@@ -50,12 +69,14 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
 
     private var rtmpConnection: RTMPConnection?
     private var rtmpStream: RTMPStream?
+    private var audioMixer: MediaMixer?
 
     private var rtmpUrl: String = ""
     private var streamKey: String = ""
     private var videoWidth: Int = 0
     private var videoHeight: Int = 0
     private var bitrate: Int = RTMPStreamingService.defaultBitrate
+    private var encodingMode: RTMPVideoEncodingMode = .h264
 
     // State
     private(set) var isStreaming = false
@@ -63,10 +84,6 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
 
     // Frame tracking
     private var totalFrames: Int64 = 0
-    private var frameIndex: Int64 = 0
-    private var baseTimestamp: Int64 = 0
-    private let targetFrameDuration: Int64 = 1_000_000 / Int64(RTMPStreamingService.defaultFPS)
-
     // Callbacks
     var onStateChanged: ((RTMPStreamingState) -> Void)?
     var onStatsUpdated: ((RTMPStreamingStats) -> Void)?
@@ -92,18 +109,25 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
     // MARK: - Public Methods
 
     /// Start RTMP streaming
-    func startStreaming(url: String, width: Int, height: Int, bitrate: Int = defaultBitrate) {
+    func startStreaming(
+        url: String,
+        width: Int,
+        height: Int,
+        bitrate: Int = defaultBitrate,
+        encodingMode: RTMPVideoEncodingMode = .h264
+    ) {
         guard !isStreaming else {
             logger.warning("Already streaming")
             return
         }
 
         logger.info("Starting RTMP streaming to: \(url)")
-        logger.info("Video: \(width)x\(height) @ \(bitrate) bps")
+        logger.info("Video: \(width)x\(height) @ \(bitrate) bps, codec: \(encodingMode.rawValue)")
 
         self.videoWidth = width
         self.videoHeight = height
         self.bitrate = bitrate
+        self.encodingMode = encodingMode
 
         // Parse URL to get server URL and stream key
         guard let urlComponents = parseRTMPUrl(url) else {
@@ -145,6 +169,7 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
         let connectionToClose = rtmpConnection
         rtmpStream = nil
         rtmpConnection = nil
+        stopAudioCapture()
 
         shutdownTask?.cancel()
         shutdownTask = Task.detached { [statusTaskToStop, streamStatusTaskToStop, streamToClose, connectionToClose] in
@@ -160,8 +185,6 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
 
         // Reset state
         totalFrames = 0
-        frameIndex = 0
-        baseTimestamp = 0
         startTime = nil
 
         onStateChanged?(.idle)
@@ -195,6 +218,24 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
         updateStats()
     }
 
+    func feedSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
+        lock.lock()
+        let streaming = isStreaming
+        let stream = rtmpStream
+        if streaming {
+            totalFrames += 1
+        }
+        lock.unlock()
+
+        guard streaming, let stream else { return }
+
+        Task {
+            await stream.append(sampleBuffer)
+        }
+
+        updateStats()
+    }
+
     // MARK: - Private Methods
 
     private func setupAndConnect() async {
@@ -221,8 +262,9 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
         } catch {
             logger.error("RTMP: Connection failed: \(error.localizedDescription)")
             await MainActor.run {
-                onStateChanged?(.error(error.localizedDescription))
-                onError?(error.localizedDescription)
+                let message = formatRTMPError(error, fallback: "Failed to connect to RTMP server")
+                onStateChanged?(.error(message))
+                onError?(message)
             }
         }
     }
@@ -237,13 +279,33 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
         videoSettings.videoSize = CGSize(width: videoWidth, height: videoHeight)
         videoSettings.bitRate = bitrate
         videoSettings.maxKeyFrameIntervalDuration = 1
-        videoSettings.profileLevel = kVTProfileLevel_H264_Main_AutoLevel as String
+        switch encodingMode {
+        case .h264:
+            videoSettings.profileLevel = kVTProfileLevel_H264_Main_AutoLevel as String
+        case .hevc:
+            videoSettings.profileLevel = kVTProfileLevel_HEVC_Main_AutoLevel as String
+        }
         try? await stream.setVideoSettings(videoSettings)
+
+        var audioSettings = AudioCodecSettings()
+        audioSettings.format = .aac
+        audioSettings.bitRate = 128_000
+        try? await stream.setAudioSettings(audioSettings)
 
         // Monitor stream status
         streamStatusTask = Task { [weak self] in
             for await status in await stream.status {
                 await self?.handleStreamStatus(status)
+            }
+        }
+
+        do {
+            try await startAudioCapture(for: stream)
+            try await Task.sleep(nanoseconds: 300_000_000)
+        } catch {
+            logger.error("RTMP: Audio capture failed before publish: \(error.localizedDescription)")
+            await MainActor.run {
+                onError?("RTMP audio failed: \(error.localizedDescription)")
             }
         }
 
@@ -260,12 +322,66 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
                 self?.onStateChanged?(.streaming)
             }
         } catch {
+            await stopAudioCapture()
             logger.error("RTMP: Publish failed: \(error.localizedDescription)")
             await MainActor.run {
-                onStateChanged?(.error(error.localizedDescription))
-                onError?(error.localizedDescription)
+                let message = formatRTMPError(error, fallback: "Failed to publish stream. Check the RTMP URL, stream key, and auth parameters.")
+                onStateChanged?(.error(message))
+                onError?(message)
             }
         }
+    }
+
+    private func startAudioCapture(for stream: RTMPStream) async throws {
+        await stopAudioCapture()
+
+        let audioSession = AVAudioSession.sharedInstance()
+        guard AVAudioApplication.shared.recordPermission == .granted else {
+            throw NSError(
+                domain: "RTMPStreamingAudio",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Microphone permission is required for RTMP audio"]
+            )
+        }
+
+        try audioSession.setCategory(.playAndRecord, mode: .videoRecording, options: [.allowBluetoothHFP, .defaultToSpeaker, .mixWithOthers])
+        try audioSession.setActive(true)
+
+        let mixer = MediaMixer(captureSessionMode: .single)
+        try await mixer.attachAudio(AVCaptureDevice.default(for: .audio))
+        await mixer.addOutput(stream)
+        await mixer.startRunning()
+        audioMixer = mixer
+
+        logger.info("RTMP: Audio capture started through HaishinKit MediaMixer")
+    }
+
+    private func stopAudioCapture() {
+        guard let mixer = audioMixer else { return }
+        audioMixer = nil
+
+        Task {
+            await mixer.stopRunning()
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            logger.info("RTMP: Audio capture stopped")
+        }
+    }
+
+    private func stopAudioCapture() async {
+        guard let mixer = audioMixer else { return }
+        audioMixer = nil
+
+        await mixer.stopRunning()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        logger.info("RTMP: Audio capture stopped")
+    }
+
+    private func formatRTMPError(_ error: Error, fallback: String) -> String {
+        let nsError = error as NSError
+        if nsError.domain.contains("RTMP") {
+            return fallback
+        }
+        return error.localizedDescription
     }
 
     @MainActor
@@ -312,19 +428,26 @@ class RTMPStreamingService: NSObject, @unchecked Sendable {
         guard let urlObj = URL(string: url) else { return nil }
 
         let pathComponents = urlObj.path.split(separator: "/")
+        let portPart = urlObj.port.map { ":\($0)" } ?? ""
         guard pathComponents.count >= 2 else {
             // If only one path component, use it as stream key with default app
-            let streamKey = pathComponents.first.map(String.init) ?? "stream"
-            let serverUrl = "\(urlObj.scheme ?? "rtmp")://\(urlObj.host ?? "localhost"):\(urlObj.port ?? 1935)/live"
+            var streamKey = pathComponents.first.map(String.init) ?? "stream"
+            if let query = urlObj.query, !query.isEmpty {
+                streamKey += "?\(query)"
+            }
+            let serverUrl = "\(urlObj.scheme ?? "rtmp")://\(urlObj.host ?? "localhost")\(portPart)/live"
             return (serverUrl, streamKey)
         }
 
         // Last component is stream key
-        let streamKey = String(pathComponents.last!)
+        var streamKey = String(pathComponents.last!)
+        if let query = urlObj.query, !query.isEmpty {
+            streamKey += "?\(query)"
+        }
 
         // Everything before is the server URL with app
         let appPath = pathComponents.dropLast().map(String.init).joined(separator: "/")
-        let serverUrl = "\(urlObj.scheme ?? "rtmp")://\(urlObj.host ?? "localhost"):\(urlObj.port ?? 1935)/\(appPath)"
+        let serverUrl = "\(urlObj.scheme ?? "rtmp")://\(urlObj.host ?? "localhost")\(portPart)/\(appPath)"
 
         return (serverUrl, streamKey)
     }
@@ -422,43 +545,4 @@ extension UIImage {
         return sampleBuffer
     }
 
-    func toPixelBuffer() -> CVPixelBuffer? {
-        let width = Int(size.width)
-        let height = Int(size.height)
-
-        var pixelBuffer: CVPixelBuffer?
-        let attrs: [String: Any] = [
-            kCVPixelBufferCGImageCompatibilityKey as String: true,
-            kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
-        ]
-
-        let status = CVPixelBufferCreate(
-            kCFAllocatorDefault,
-            width,
-            height,
-            kCVPixelFormatType_32BGRA,
-            attrs as CFDictionary,
-            &pixelBuffer
-        )
-
-        guard status == kCVReturnSuccess, let buffer = pixelBuffer else { return nil }
-
-        CVPixelBufferLockBaseAddress(buffer, [])
-        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
-
-        guard let context = CGContext(
-            data: CVPixelBufferGetBaseAddress(buffer),
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
-        ) else { return nil }
-
-        guard let cgImage = cgImage else { return nil }
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
-
-        return buffer
-    }
 }

--- a/CameraAccess/Services/TTSService.swift
+++ b/CameraAccess/Services/TTSService.swift
@@ -125,15 +125,15 @@ class TTSService: NSObject, ObservableObject {
 
     /// 播报文本
     /// - 阿里云 API：使用阿里云 qwen3-tts-flash
-    /// - OpenRouter API：使用系统 TTS
+    /// - OpenRouter/AIHubMix API：使用系统 TTS
     func speak(_ text: String, apiKey: String? = nil) {
         // 取消之前的任务
         currentTask?.cancel()
         stop()
 
-        // OpenRouter 使用系统 TTS
-        if APIProviderManager.staticCurrentProvider == .openrouter {
-            print("🔊 [TTS] OpenRouter mode, using system TTS")
+        // Non-Alibaba providers do not use Alibaba qwen3-tts-flash.
+        if APIProviderManager.staticCurrentProvider != .alibaba {
+            print("🔊 [TTS] Non-Alibaba provider, using system TTS")
             isSpeaking = true
             currentTask = Task {
                 await fallbackToSystemTTS(text: text)

--- a/CameraAccess/Services/VisionAPIConfig.swift
+++ b/CameraAccess/Services/VisionAPIConfig.swift
@@ -1,7 +1,7 @@
 /*
  * Vision API Configuration
  * Centralized configuration for Vision API
- * Supports multiple providers: Alibaba Cloud Dashscope, OpenRouter
+ * Supports multiple providers: Alibaba Cloud Dashscope, OpenRouter, AIHubMix
  */
 
 import Foundation
@@ -38,10 +38,14 @@ struct VisionAPIConfig {
     /// OpenRouter API URL
     static let openRouterURL = "https://openrouter.ai/api/v1"
 
+    /// AIHubMix API URL
+    static let aiHubMixURL = "https://aihubmix.com/v1"
+
     // MARK: - Default Models
 
     static let defaultAlibabaModel = "qwen3-vl-plus"
     static let defaultOpenRouterModel = "google/gemini-3-flash-preview"
+    static let defaultAIHubMixModel = "gpt-5.4"
 
     // MARK: - Request Headers
 

--- a/CameraAccess/Utils/APIKeyManager.swift
+++ b/CameraAccess/Utils/APIKeyManager.swift
@@ -1,7 +1,7 @@
 /*
  * API Key Manager
  * Secure storage and retrieval of API keys using Keychain
- * Supports multiple API providers (Alibaba Dashscope, OpenRouter, Google)
+ * Supports multiple API providers (Alibaba Dashscope, OpenRouter, AIHubMix, Google)
  */
 
 import Foundation
@@ -16,6 +16,7 @@ class APIKeyManager {
     private let alibabaBeijingAccount = "alibaba-beijing-api-key"
     private let alibabaSingaporeAccount = "alibaba-singapore-api-key"
     private let openrouterAccount = "openrouter-api-key"
+    private let aihubmixAccount = "aihubmix-api-key"
     private let googleAccount = "google-api-key"
     private let legacyAccount = "qwen-api-key" // For backward compatibility (migrates to Beijing)
     private let legacyAlibabaAccount = "alibaba-api-key" // Old format (migrates to Beijing)
@@ -118,6 +119,8 @@ class APIKeyManager {
             }
         case .openrouter:
             return openrouterAccount
+        case .aihubmix:
+            return aihubmixAccount
         }
     }
 

--- a/CameraAccess/ViewModels/LiveTranslateViewModel.swift
+++ b/CameraAccess/ViewModels/LiveTranslateViewModel.swift
@@ -95,7 +95,7 @@ class LiveTranslateViewModel: ObservableObject {
     // MARK: - Connection
 
     func connect() {
-        let apiKey = APIProviderManager.staticLiveAIAPIKey
+        let apiKey = APIKeyManager.shared.getAPIKey(for: .alibaba, endpoint: APIProviderManager.staticAlibabaEndpoint) ?? ""
         guard !apiKey.isEmpty else {
             errorMessage = "livetranslate.error.noApiKey".localized
             showError = true

--- a/CameraAccess/ViewModels/OmniRealtimeViewModel.swift
+++ b/CameraAccess/ViewModels/OmniRealtimeViewModel.swift
@@ -25,6 +25,10 @@ class OmniRealtimeViewModel: ObservableObject {
     private var geminiService: GeminiLiveService?
     private let provider: LiveAIProvider
     private let apiKey: String
+    private let liveAIModel: String
+    private var imageSendTimer: Timer?
+    private var lastImageSendTime: Date?
+    private let imageSendInterval: TimeInterval = 1.0
 
     // Video frame
     private var currentVideoFrame: UIImage?
@@ -33,13 +37,14 @@ class OmniRealtimeViewModel: ObservableObject {
     init(apiKey: String) {
         self.apiKey = apiKey
         self.provider = APIProviderManager.staticLiveAIProvider
+        self.liveAIModel = APIProviderManager.staticLiveAIModel
 
         // Initialize appropriate service based on provider
         switch provider {
         case .alibaba:
             self.omniService = OmniRealtimeService(apiKey: apiKey)
         case .google:
-            self.geminiService = GeminiLiveService(apiKey: apiKey)
+            self.geminiService = GeminiLiveService(apiKey: apiKey, model: liveAIModel)
         }
 
         setupCallbacks()
@@ -70,7 +75,8 @@ class OmniRealtimeViewModel: ObservableObject {
                 print("✅ [OmniVM] 收到第一次音频发送回调，启用图片发送")
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                     self?.isImageSendingEnabled = true
-                    print("📸 [OmniVM] 图片发送已启用（语音触发模式）")
+                    print("📸 [OmniVM] 图片发送已启用（连续视觉模式）")
+                    self?.startImageSending()
                 }
             }
         }
@@ -79,11 +85,9 @@ class OmniRealtimeViewModel: ObservableObject {
             Task { @MainActor in
                 self?.isSpeaking = true
 
-                if let strongSelf = self,
-                   strongSelf.isImageSendingEnabled,
-                   let frame = strongSelf.currentVideoFrame {
+                if let strongSelf = self, strongSelf.isImageSendingEnabled {
                     print("🎤📸 [OmniVM] 检测到用户语音，发送当前视频帧")
-                    strongSelf.omniService?.sendImageAppend(frame)
+                    strongSelf.sendLatestImage(force: true)
                 }
             }
         }
@@ -155,7 +159,8 @@ class OmniRealtimeViewModel: ObservableObject {
                 print("✅ [GeminiVM] 收到第一次音频发送回调，启用图片发送")
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                     self?.isImageSendingEnabled = true
-                    print("📸 [GeminiVM] 图片发送已启用（语音触发模式）")
+                    print("📸 [GeminiVM] 图片发送已启用（连续视觉模式）")
+                    self?.startImageSending()
                 }
             }
         }
@@ -164,11 +169,9 @@ class OmniRealtimeViewModel: ObservableObject {
             Task { @MainActor in
                 self?.isSpeaking = true
 
-                if let strongSelf = self,
-                   strongSelf.isImageSendingEnabled,
-                   let frame = strongSelf.currentVideoFrame {
+                if let strongSelf = self, strongSelf.isImageSendingEnabled {
                     print("🎤📸 [GeminiVM] 检测到用户语音，发送当前视频帧")
-                    strongSelf.geminiService?.sendImageInput(frame)
+                    strongSelf.sendLatestImage(force: true)
                 }
             }
         }
@@ -252,6 +255,7 @@ class OmniRealtimeViewModel: ObservableObject {
 
         isConnected = false
         isImageSendingEnabled = false
+        stopImageSending()
     }
 
     private func saveConversation() {
@@ -261,18 +265,10 @@ class OmniRealtimeViewModel: ObservableObject {
             return
         }
 
-        let aiModel: String
-        switch provider {
-        case .alibaba:
-            aiModel = "qwen3-omni-flash-realtime"
-        case .google:
-            aiModel = "gemini-2.0-flash-exp"
-        }
-
         let record = ConversationRecord(
             messages: conversationHistory,
-            aiModel: aiModel,
-            language: "zh-CN" // TODO: 从设置中获取
+            aiModel: liveAIModel,
+            language: "auto-bilingual"
         )
 
         ConversationStorage.shared.saveConversation(record)
@@ -299,6 +295,9 @@ class OmniRealtimeViewModel: ObservableObject {
         }
 
         isRecording = true
+        if isImageSendingEnabled {
+            startImageSending()
+        }
     }
 
     func stopRecording() {
@@ -312,12 +311,50 @@ class OmniRealtimeViewModel: ObservableObject {
         }
 
         isRecording = false
+        stopImageSending()
     }
 
     // MARK: - Video Frames
 
     func updateVideoFrame(_ frame: UIImage) {
         currentVideoFrame = frame
+    }
+
+    private func startImageSending() {
+        guard isConnected, isRecording else { return }
+        guard imageSendTimer == nil else { return }
+
+        sendLatestImage(force: true)
+        imageSendTimer = Timer.scheduledTimer(withTimeInterval: imageSendInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.sendLatestImage(force: false)
+            }
+        }
+    }
+
+    private func stopImageSending() {
+        imageSendTimer?.invalidate()
+        imageSendTimer = nil
+        lastImageSendTime = nil
+    }
+
+    private func sendLatestImage(force: Bool) {
+        guard isConnected, isRecording, isImageSendingEnabled, let frame = currentVideoFrame else {
+            return
+        }
+
+        if !force, let lastImageSendTime, Date().timeIntervalSince(lastImageSendTime) < imageSendInterval {
+            return
+        }
+
+        lastImageSendTime = Date()
+
+        switch provider {
+        case .alibaba:
+            omniService?.sendImageAppend(frame)
+        case .google:
+            geminiService?.sendImageInput(frame)
+        }
     }
 
     // MARK: - Manual Mode (if needed)

--- a/CameraAccess/ViewModels/RTMPStreamingViewModel.swift
+++ b/CameraAccess/ViewModels/RTMPStreamingViewModel.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import Combine
 import Security
+import CoreMedia
 import os.log
 
 private let logger = Logger(subsystem: "com.smartview.glassai", category: "RTMPStreaming")
@@ -18,7 +19,8 @@ class RTMPStreamingViewModel: ObservableObject {
     @Published var rtmpUrl: String = ""
     @Published var streamKey: String = ""
     @Published var selectedPlatform: StreamingPlatform = .custom
-    @Published var bitrate: Int = 2_000_000 // 2 Mbps
+    @Published var bitrate: Int = 6_000_000 // 6 Mbps
+    @Published var encodingMode: RTMPVideoEncodingMode = .h264
 
     @Published var isStreaming: Bool = false
     @Published var isConnecting: Bool = false
@@ -28,6 +30,8 @@ class RTMPStreamingViewModel: ObservableObject {
     @Published var currentFps: Double = 0.0
     @Published var connectionTime: TimeInterval = 0
     @Published var bytesSent: Int64 = 0
+    @Published var sourceResolution: String = "-"
+    @Published var outputResolution: String = "-"
 
     @Published var showError: Bool = false
     @Published var errorMessage: String?
@@ -113,7 +117,6 @@ class RTMPStreamingViewModel: ObservableObject {
     // MARK: - Private Properties
 
     private let streamingService: RTMPStreamingService
-    private weak var streamViewModel: StreamSessionViewModel?
     private var statsTimer: Timer?
     private var startTime: Date?
 
@@ -133,10 +136,6 @@ class RTMPStreamingViewModel: ObservableObject {
 
     // MARK: - Public Methods
 
-    func setStreamViewModel(_ viewModel: StreamSessionViewModel) {
-        self.streamViewModel = viewModel
-    }
-
     func selectPlatform(_ platform: StreamingPlatform) {
         selectedPlatform = platform
         if platform != .custom {
@@ -144,9 +143,14 @@ class RTMPStreamingViewModel: ObservableObject {
         }
     }
 
-    func startStreaming() {
+    func startStreaming(videoFrame: UIImage?, sampleBuffer: CMSampleBuffer?) {
         guard !isStreaming else {
             logger.warning("Already streaming")
+            return
+        }
+
+        guard hasCompleteRTMPDestination() else {
+            showError(message: "rtmp.error.missingkey".localized)
             return
         }
 
@@ -161,11 +165,25 @@ class RTMPStreamingViewModel: ObservableObject {
         isConnecting = true
         connectionStatus = .connecting
 
-        // Get video dimensions from current frame
-        let width = 504  // Default from Ray-Ban Meta
-        let height = 504
+        guard let dimensions = videoDimensions(videoFrame: videoFrame, sampleBuffer: sampleBuffer) else {
+            isConnecting = false
+            connectionStatus = .disconnected
+            showError(message: "rtmp.error.novideo".localized)
+            return
+        }
 
-        streamingService.startStreaming(url: fullUrl, width: width, height: height, bitrate: bitrate)
+        let outputBitrate = max(bitrate, recommendedBitrate(width: dimensions.width, height: dimensions.height))
+        sourceResolution = "\(dimensions.width)x\(dimensions.height)"
+        outputResolution = "\(dimensions.width)x\(dimensions.height)"
+        logger.info("RTMP video dimensions: \(dimensions.width)x\(dimensions.height), bitrate: \(outputBitrate), codec: \(self.encodingMode.rawValue)")
+
+        streamingService.startStreaming(
+            url: fullUrl,
+            width: dimensions.width,
+            height: dimensions.height,
+            bitrate: outputBitrate,
+            encodingMode: encodingMode
+        )
 
         saveSettings()
     }
@@ -185,11 +203,31 @@ class RTMPStreamingViewModel: ObservableObject {
         currentFps = 0.0
         connectionTime = 0
         bytesSent = 0
+        outputResolution = "-"
     }
 
     func feedFrame(_ image: UIImage, timestamp: Int64) {
+        let dimensions = videoDimensions(from: image)
+        let resolution = "\(dimensions.width)x\(dimensions.height)"
+        if sourceResolution != resolution {
+            sourceResolution = resolution
+            logger.info("RTMP source frame dimensions changed: \(resolution)")
+        }
         guard isStreaming else { return }
         streamingService.feedFrame(image, timestamp: timestamp)
+    }
+
+    func feedSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
+        if let dimensions = sampleBufferDimensions(sampleBuffer) {
+            let resolution = "\(dimensions.width)x\(dimensions.height)"
+            if sourceResolution != resolution {
+                sourceResolution = resolution
+                outputResolution = resolution
+                logger.info("RTMP source sampleBuffer dimensions changed: \(resolution)")
+            }
+        }
+        guard isStreaming else { return }
+        streamingService.feedSampleBuffer(sampleBuffer)
     }
 
     func dismissError() {
@@ -261,6 +299,10 @@ class RTMPStreamingViewModel: ObservableObject {
 
         guard !url.isEmpty else { return "" }
 
+        if isCompleteRTMPUrl(url) {
+            return url
+        }
+
         if !key.isEmpty {
             if !url.hasSuffix("/") {
                 url += "/"
@@ -269,6 +311,77 @@ class RTMPStreamingViewModel: ObservableObject {
         }
 
         return url
+    }
+
+    private func isCompleteRTMPUrl(_ url: String) -> Bool {
+        guard let urlObj = URL(string: url),
+              let scheme = urlObj.scheme?.lowercased(),
+              scheme == "rtmp" || scheme == "rtmps" else {
+            return false
+        }
+
+        return urlObj.path.split(separator: "/").count >= 2
+    }
+
+    private func hasCompleteRTMPDestination() -> Bool {
+        let url = rtmpUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = streamKey.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let urlObj = URL(string: url),
+              let scheme = urlObj.scheme?.lowercased(),
+              scheme == "rtmp" || scheme == "rtmps" else {
+            return false
+        }
+
+        if !key.isEmpty {
+            return true
+        }
+
+        let pathComponents = urlObj.path.split(separator: "/")
+        return pathComponents.count >= 2
+    }
+
+    private func videoDimensions(from image: UIImage) -> (width: Int, height: Int) {
+        if let cgImage = image.cgImage {
+            return (cgImage.width, cgImage.height)
+        }
+
+        let scale = max(image.scale, 1)
+        return (Int(image.size.width * scale), Int(image.size.height * scale))
+    }
+
+    private func videoDimensions(videoFrame: UIImage?, sampleBuffer: CMSampleBuffer?) -> (width: Int, height: Int)? {
+        switch encodingMode {
+        case .h264:
+            guard let videoFrame else { return nil }
+            return videoDimensions(from: videoFrame)
+        case .hevc:
+            if let sampleBuffer, let dimensions = sampleBufferDimensions(sampleBuffer) {
+                return dimensions
+            }
+            if let videoFrame {
+                return videoDimensions(from: videoFrame)
+            }
+            return nil
+        }
+    }
+
+    private func sampleBufferDimensions(_ sampleBuffer: CMSampleBuffer) -> (width: Int, height: Int)? {
+        guard let formatDescription = sampleBuffer.formatDescription else { return nil }
+        let dimensions = CMVideoFormatDescriptionGetDimensions(formatDescription)
+        guard dimensions.width > 0, dimensions.height > 0 else { return nil }
+        return (Int(dimensions.width), Int(dimensions.height))
+    }
+
+    private func recommendedBitrate(width: Int, height: Int) -> Int {
+        let pixels = width * height
+        if pixels >= 1_900_000 {
+            return 8_000_000
+        }
+        if pixels >= 900_000 {
+            return 6_000_000
+        }
+        return 4_000_000
     }
 
     private func startStatsTimer() {
@@ -290,6 +403,7 @@ class RTMPStreamingViewModel: ObservableObject {
         UserDefaults.standard.set(rtmpUrl, forKey: "rtmp_url")
         UserDefaults.standard.set(selectedPlatform.rawValue, forKey: "rtmp_platform")
         UserDefaults.standard.set(bitrate, forKey: "rtmp_bitrate")
+        UserDefaults.standard.set(encodingMode.rawValue, forKey: "rtmp_video_codec")
         // Stream key is sensitive, store in Keychain
         saveStreamKeyToKeychain(streamKey)
     }
@@ -305,7 +419,11 @@ class RTMPStreamingViewModel: ObservableObject {
         }
         let savedBitrate = UserDefaults.standard.integer(forKey: "rtmp_bitrate")
         if savedBitrate > 0 {
-            bitrate = savedBitrate
+            bitrate = max(savedBitrate, 6_000_000)
+        }
+        if let savedCodec = UserDefaults.standard.string(forKey: "rtmp_video_codec"),
+           let codec = RTMPVideoEncodingMode(rawValue: savedCodec) {
+            encodingMode = codec
         }
         // Migrate old UserDefaults key to Keychain
         if let oldKey = UserDefaults.standard.string(forKey: "rtmp_stream_key"), !oldKey.isEmpty {

--- a/CameraAccess/ViewModels/StreamSessionViewModel.swift
+++ b/CameraAccess/ViewModels/StreamSessionViewModel.swift
@@ -17,6 +17,7 @@
 import MWDATCamera
 import MWDATCore
 import SwiftUI
+import CoreMedia
 import os.log
 
 private let logger = Logger(subsystem: "com.smartview.glassai", category: "StreamSession")
@@ -30,6 +31,7 @@ enum StreamingStatus {
 @MainActor
 class StreamSessionViewModel: ObservableObject {
   @Published var currentVideoFrame: UIImage?
+  @Published var currentSampleBuffer: CMSampleBuffer?
   @Published var hasReceivedFirstFrame: Bool = false
   @Published var streamingStatus: StreamingStatus = .stopped
   @Published var showError: Bool = false
@@ -71,25 +73,8 @@ class StreamSessionViewModel: ObservableObject {
     // Let the SDK auto-select from available devices
     self.deviceSelector = AutoDeviceSelector(wearables: wearables)
 
-    // Get saved video quality setting from UserDefaults (only read at init)
-    let savedQuality = UserDefaults.standard.string(forKey: "video_quality") ?? "medium"
-    let resolution: StreamingResolution
-    switch savedQuality {
-    case "low":
-      resolution = .low
-    case "high":
-      resolution = .high
-    default:
-      resolution = .medium
-    }
-    logger.info("🟢 Using video quality: \(savedQuality) -> \(String(describing: resolution))")
-
     // Create ONE session at init - SDK pattern requires reusing same session
-    let config = StreamSessionConfig(
-      videoCodec: VideoCodec.raw,
-      resolution: resolution,
-      frameRate: 24)
-    streamSession = StreamSession(streamSessionConfig: config, deviceSelector: deviceSelector)
+    streamSession = Self.makeStreamSession(deviceSelector: deviceSelector)
     logger.info("🟢 StreamSession created")
 
     // Monitor device availability
@@ -100,54 +85,7 @@ class StreamSessionViewModel: ObservableObject {
       }
     }
 
-    // Subscribe to session state changes
-    stateListenerToken = streamSession.statePublisher.listen { [weak self] state in
-      Task { @MainActor [weak self] in
-        logger.info("📊 State changed: \(String(describing: state))")
-        self?.updateStatusFromState(state)
-      }
-    }
-
-    // Subscribe to video frames (skip if previous frame still processing)
-    videoFrameListenerToken = streamSession.videoFramePublisher.listen { [weak self] videoFrame in
-      Task { @MainActor [weak self] in
-        guard let self, !self.isProcessingFrame else { return }
-        self.isProcessingFrame = true
-        defer { self.isProcessingFrame = false }
-
-        if let image = videoFrame.makeUIImage() {
-          self.currentVideoFrame = image
-          if !self.hasReceivedFirstFrame {
-            logger.info("🎥 First frame received and converted")
-            self.hasReceivedFirstFrame = true
-          }
-        }
-      }
-    }
-
-    // Subscribe to errors
-    errorListenerToken = streamSession.errorPublisher.listen { [weak self] error in
-      Task { @MainActor [weak self] in
-        guard let self else { return }
-        logger.error("❌ Stream error: \(String(describing: error))")
-        let newErrorMessage = formatStreamingError(error)
-        if newErrorMessage != self.errorMessage {
-          showError(newErrorMessage)
-        }
-      }
-    }
-
-    // Subscribe to photo capture
-    photoDataListenerToken = streamSession.photoDataPublisher.listen { [weak self] photoData in
-      Task { @MainActor [weak self] in
-        guard let self else { return }
-        logger.info("📸 Photo captured - size: \(photoData.data.count) bytes")
-        if let uiImage = UIImage(data: photoData.data) {
-          self.capturedPhoto = uiImage
-          self.showPhotoPreview = true
-        }
-      }
-    }
+    subscribeToStreamSession()
 
     updateStatusFromState(streamSession.state)
     logger.info("🟢 StreamSessionViewModel init complete")
@@ -173,6 +111,42 @@ class StreamSessionViewModel: ObservableObject {
     } catch {
       logger.error("❌ Permission error: \(error.localizedDescription)")
       showError("Permission error: \(error.description)")
+    }
+  }
+
+  func applyVideoQuality(_ quality: String) async {
+    UserDefaults.standard.set(quality, forKey: "video_quality")
+    logger.info("🎥 Applying video quality: \(quality)")
+    await recreateStreamSession()
+  }
+
+  func applyRTMPEncodingMode(_ mode: RTMPVideoEncodingMode) async {
+    UserDefaults.standard.set(mode.rawValue, forKey: "rtmp_video_codec")
+    logger.info("🎥 Applying RTMP video codec: \(mode.rawValue)")
+    await recreateStreamSession()
+  }
+
+  private func recreateStreamSession() async {
+    let wasStreaming = streamingStatus != .stopped
+    if wasStreaming {
+      await streamSession.stop()
+    }
+
+    stateListenerToken = nil
+    videoFrameListenerToken = nil
+    errorListenerToken = nil
+    photoDataListenerToken = nil
+    currentVideoFrame = nil
+    currentSampleBuffer = nil
+    hasReceivedFirstFrame = false
+    isProcessingFrame = false
+
+    streamSession = Self.makeStreamSession(deviceSelector: deviceSelector)
+    subscribeToStreamSession()
+    updateStatusFromState(streamSession.state)
+
+    if wasStreaming {
+      await startSession()
     }
   }
 
@@ -254,6 +228,7 @@ class StreamSessionViewModel: ObservableObject {
     case .stopped:
       logger.info("📊 State is STOPPED - clearing frame")
       currentVideoFrame = nil
+      currentSampleBuffer = nil
       streamingStatus = .stopped
     case .waitingForDevice, .starting, .stopping, .paused:
       logger.info("📊 State is WAITING (\(String(describing: state)))")
@@ -261,6 +236,82 @@ class StreamSessionViewModel: ObservableObject {
     case .streaming:
       logger.info("📊 State is STREAMING ✅")
       streamingStatus = .streaming
+    }
+  }
+
+  private static func makeStreamSession(deviceSelector: AutoDeviceSelector) -> StreamSession {
+    let quality = UserDefaults.standard.string(forKey: "video_quality") ?? "high"
+    let resolution: StreamingResolution
+    switch quality {
+    case "low":
+      resolution = .low
+    case "medium":
+      resolution = .medium
+    default:
+      resolution = .high
+    }
+
+    logger.info("🟢 Using video quality: \(quality) -> \(String(describing: resolution))")
+    let codecSetting = UserDefaults.standard.string(forKey: "rtmp_video_codec") ?? RTMPVideoEncodingMode.h264.rawValue
+    let videoCodec: VideoCodec = codecSetting == RTMPVideoEncodingMode.hevc.rawValue ? .hvc1 : .raw
+    logger.info("🟢 Using video codec: \(codecSetting) -> \(String(describing: videoCodec))")
+
+    let config = StreamSessionConfig(
+      videoCodec: videoCodec,
+      resolution: resolution,
+      frameRate: 24)
+    return StreamSession(streamSessionConfig: config, deviceSelector: deviceSelector)
+  }
+
+  private func subscribeToStreamSession() {
+    stateListenerToken = streamSession.statePublisher.listen { [weak self] state in
+      Task { @MainActor [weak self] in
+        logger.info("📊 State changed: \(String(describing: state))")
+        self?.updateStatusFromState(state)
+      }
+    }
+
+    videoFrameListenerToken = streamSession.videoFramePublisher.listen { [weak self] videoFrame in
+      Task { @MainActor [weak self] in
+        guard let self, !self.isProcessingFrame else { return }
+        self.isProcessingFrame = true
+        defer { self.isProcessingFrame = false }
+
+        self.currentSampleBuffer = videoFrame.sampleBuffer
+
+        if let image = videoFrame.makeUIImage() {
+          self.currentVideoFrame = image
+          if !self.hasReceivedFirstFrame {
+            logger.info("🎥 First frame received and converted")
+            self.hasReceivedFirstFrame = true
+          }
+        } else if !self.hasReceivedFirstFrame {
+          logger.info("🎥 First compressed frame received")
+          self.hasReceivedFirstFrame = true
+        }
+      }
+    }
+
+    errorListenerToken = streamSession.errorPublisher.listen { [weak self] error in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        logger.error("❌ Stream error: \(String(describing: error))")
+        let newErrorMessage = formatStreamingError(error)
+        if newErrorMessage != self.errorMessage {
+          showError(newErrorMessage)
+        }
+      }
+    }
+
+    photoDataListenerToken = streamSession.photoDataPublisher.listen { [weak self] photoData in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        logger.info("📸 Photo captured - size: \(photoData.data.count) bytes")
+        if let uiImage = UIImage(data: photoData.data) {
+          self.capturedPhoto = uiImage
+          self.showPhotoPreview = true
+        }
+      }
     }
   }
 

--- a/CameraAccess/Views/LiveAIView.swift
+++ b/CameraAccess/Views/LiveAIView.swift
@@ -111,8 +111,10 @@ struct LiveAIView: View {
             // 更新视频帧
             frameTimer?.invalidate()
             frameTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-                if let frame = streamViewModel.currentVideoFrame {
-                    viewModel.updateVideoFrame(frame)
+                Task { @MainActor in
+                    if let frame = streamViewModel.currentVideoFrame {
+                        viewModel.updateVideoFrame(frame)
+                    }
                 }
             }
         }

--- a/CameraAccess/Views/RTMPStreamingView.swift
+++ b/CameraAccess/Views/RTMPStreamingView.swift
@@ -8,6 +8,7 @@
  */
 
 import SwiftUI
+import CoreMedia
 
 struct RTMPStreamingView: View {
     @ObservedObject var streamViewModel: StreamSessionViewModel
@@ -16,6 +17,8 @@ struct RTMPStreamingView: View {
 
     @State private var showUI = true
     @State private var frameTimer: Timer?
+    @State private var lastH264Frame: UIImage?
+    @State private var lastHEVCPresentationTime: CMTime = .invalid
 
     var body: some View {
         ZStack {
@@ -32,6 +35,20 @@ struct RTMPStreamingView: View {
                         .clipped()
                 }
                 .ignoresSafeArea()
+            } else if rtmpViewModel.encodingMode == .hevc && streamViewModel.currentSampleBuffer != nil {
+                VStack(spacing: AppSpacing.md) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 42))
+                        .foregroundColor(.green)
+                    Text("rtmp.hevc.ready".localized)
+                        .font(AppTypography.body)
+                        .foregroundColor(.white)
+                    Text("rtmp.hevc.previewnote".localized)
+                        .font(AppTypography.caption)
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(.white.opacity(0.7))
+                        .padding(.horizontal, AppSpacing.xl)
+                }
             } else {
                 VStack(spacing: AppSpacing.lg) {
                     ProgressView()
@@ -71,13 +88,16 @@ struct RTMPStreamingView: View {
         }
         .onAppear {
             startVideoStream()
-            rtmpViewModel.setStreamViewModel(streamViewModel)
+            UIApplication.shared.isIdleTimerDisabled = rtmpViewModel.isStreaming
         }
         .onDisappear {
             stopAll()
         }
+        .onChange(of: rtmpViewModel.isStreaming) { _, isStreaming in
+            UIApplication.shared.isIdleTimerDisabled = isStreaming
+        }
         .sheet(isPresented: $rtmpViewModel.showSettings) {
-            RTMPSettingsView(viewModel: rtmpViewModel)
+            RTMPSettingsView(viewModel: rtmpViewModel, streamViewModel: streamViewModel)
         }
         .alert("error".localized, isPresented: $rtmpViewModel.showError) {
             Button("ok".localized) {
@@ -151,13 +171,16 @@ struct RTMPStreamingView: View {
     // MARK: - Stats View
 
     private var statsView: some View {
-        HStack(spacing: AppSpacing.lg) {
-            StatItem(label: "FPS", value: String(format: "%.1f", rtmpViewModel.currentFps))
-            StatItem(label: "rtmp.frames".localized, value: "\(rtmpViewModel.framesSent)")
-            StatItem(label: "rtmp.time".localized, value: formatTime(rtmpViewModel.connectionTime))
-            StatItem(label: "rtmp.data".localized, value: formatBytes(rtmpViewModel.bytesSent))
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: AppSpacing.lg) {
+                StatItem(label: "FPS", value: String(format: "%.1f", rtmpViewModel.currentFps))
+                StatItem(label: "源", value: rtmpViewModel.sourceResolution)
+                StatItem(label: "推流", value: rtmpViewModel.outputResolution)
+                StatItem(label: "rtmp.frames".localized, value: "\(rtmpViewModel.framesSent)")
+                StatItem(label: "rtmp.time".localized, value: formatTime(rtmpViewModel.connectionTime))
+            }
+            .padding(AppSpacing.md)
         }
-        .padding(AppSpacing.md)
         .background(Color.black.opacity(0.6))
         .cornerRadius(AppCornerRadius.md)
         .padding(.horizontal, AppSpacing.lg)
@@ -221,7 +244,10 @@ struct RTMPStreamingView: View {
                 if rtmpViewModel.isStreaming {
                     rtmpViewModel.stopStreaming()
                 } else {
-                    rtmpViewModel.startStreaming()
+                    rtmpViewModel.startStreaming(
+                        videoFrame: streamViewModel.currentVideoFrame,
+                        sampleBuffer: streamViewModel.currentSampleBuffer
+                    )
                 }
             } label: {
                 HStack(spacing: AppSpacing.sm) {
@@ -240,7 +266,11 @@ struct RTMPStreamingView: View {
                 .foregroundColor(.white)
                 .cornerRadius(AppCornerRadius.md)
             }
-            .disabled(rtmpViewModel.isConnecting || (rtmpViewModel.rtmpUrl.isEmpty && !rtmpViewModel.isStreaming))
+            .disabled(
+                rtmpViewModel.isConnecting ||
+                (rtmpViewModel.rtmpUrl.isEmpty && !rtmpViewModel.isStreaming) ||
+                (!rtmpViewModel.isStreaming && !hasStartableVideo)
+            )
             .padding(.horizontal, AppSpacing.lg)
         }
         .padding(.vertical, AppSpacing.lg)
@@ -263,9 +293,21 @@ struct RTMPStreamingView: View {
         // Start feeding frames to RTMP when streaming
         frameTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 24.0, repeats: true) { _ in
             Task { @MainActor in
-                if let frame = streamViewModel.currentVideoFrame {
+                guard rtmpViewModel.isStreaming else { return }
+
+                switch rtmpViewModel.encodingMode {
+                case .h264:
+                    guard let frame = streamViewModel.currentVideoFrame else { return }
+                    if let lastH264Frame, lastH264Frame === frame { return }
+                    lastH264Frame = frame
                     let timestamp = Int64(Date().timeIntervalSince1970 * 1_000_000)
                     rtmpViewModel.feedFrame(frame, timestamp: timestamp)
+                case .hevc:
+                    guard let sampleBuffer = streamViewModel.currentSampleBuffer else { return }
+                    let presentationTime = sampleBuffer.presentationTimeStamp
+                    guard presentationTime != lastHEVCPresentationTime else { return }
+                    lastHEVCPresentationTime = presentationTime
+                    rtmpViewModel.feedSampleBuffer(sampleBuffer)
                 }
             }
         }
@@ -274,10 +316,14 @@ struct RTMPStreamingView: View {
     private func stopAll() {
         frameTimer?.invalidate()
         frameTimer = nil
+        lastH264Frame = nil
+        lastHEVCPresentationTime = .invalid
 
         if rtmpViewModel.isStreaming {
             rtmpViewModel.stopStreaming()
         }
+
+        UIApplication.shared.isIdleTimerDisabled = false
 
         Task {
             if streamViewModel.streamingStatus != .stopped {
@@ -298,12 +344,12 @@ struct RTMPStreamingView: View {
         }
     }
 
-    private func formatBytes(_ bytes: Int64) -> String {
-        let mb = Double(bytes) / (1024 * 1024)
-        if mb >= 1000 {
-            return String(format: "%.1f GB", mb / 1024)
-        } else {
-            return String(format: "%.1f MB", mb)
+    private var hasStartableVideo: Bool {
+        switch rtmpViewModel.encodingMode {
+        case .h264:
+            return streamViewModel.currentVideoFrame != nil
+        case .hevc:
+            return streamViewModel.currentSampleBuffer != nil
         }
     }
 }
@@ -367,18 +413,90 @@ struct BlinkingModifier: ViewModifier {
 
 struct RTMPSettingsView: View {
     @ObservedObject var viewModel: RTMPStreamingViewModel
+    @ObservedObject var streamViewModel: StreamSessionViewModel
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("video_quality") private var videoQuality = "high"
+    @AppStorage("rtmp_video_codec") private var rtmpVideoCodec = RTMPVideoEncodingMode.h264.rawValue
 
     let bitrateOptions = [
-        (1_000_000, "1 Mbps"),
-        (2_000_000, "2 Mbps (rtmp.recommended".localized + ")"),
-        (3_000_000, "3 Mbps"),
-        (4_000_000, "4 Mbps")
+        (4_000_000, "4 Mbps"),
+        (6_000_000, "6 Mbps (rtmp.recommended".localized + ")"),
+        (8_000_000, "8 Mbps"),
+        (10_000_000, "10 Mbps")
+    ]
+
+    let qualityOptions = [
+        ("low", "settings.quality.low".localized, "settings.quality.low.desc".localized),
+        ("medium", "settings.quality.medium".localized, "settings.quality.medium.desc".localized),
+        ("high", "settings.quality.high".localized, "settings.quality.high.desc".localized)
     ]
 
     var body: some View {
         NavigationView {
             List {
+                Section {
+                    ForEach(RTMPVideoEncodingMode.allCases, id: \.self) { mode in
+                        Button {
+                            rtmpVideoCodec = mode.rawValue
+                            viewModel.encodingMode = mode
+                            Task {
+                                await streamViewModel.applyRTMPEncodingMode(mode)
+                            }
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(mode.displayName)
+                                        .foregroundColor(.primary)
+                                    Text(mode.description)
+                                        .font(AppTypography.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                if viewModel.encodingMode == mode {
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.blue)
+                                }
+                            }
+                        }
+                        .disabled(viewModel.isStreaming)
+                    }
+                } header: {
+                    Text("rtmp.codec.section".localized)
+                } footer: {
+                    Text("rtmp.codec.footer".localized)
+                }
+
+                Section {
+                    ForEach(qualityOptions, id: \.0) { quality in
+                        Button {
+                            videoQuality = quality.0
+                            Task {
+                                await streamViewModel.applyVideoQuality(quality.0)
+                            }
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(quality.1)
+                                        .foregroundColor(.primary)
+                                    Text(quality.2)
+                                        .font(AppTypography.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                if videoQuality == quality.0 {
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.blue)
+                                }
+                            }
+                        }
+                        .disabled(viewModel.isStreaming)
+                    }
+                } header: {
+                    Text("眼镜采集画质")
+                } footer: {
+                    Text("高画质会请求 720x1280；中画质通常是 504x896。请停止 RTMP 推流后切换，切换后会重启眼镜视频流。")
+                }
+
                 Section {
                     ForEach(bitrateOptions, id: \.0) { option in
                         Button {

--- a/CameraAccess/Views/SettingsView.swift
+++ b/CameraAccess/Views/SettingsView.swift
@@ -28,7 +28,7 @@ struct SettingsView: View {
     @ObservedObject var liveAIModeManager = LiveAIModeManager.shared
     @State private var selectedModel = "qwen3-omni-flash-realtime"
     @State private var selectedLanguage = "zh-CN" // 默认中文
-    @State private var selectedQuality = UserDefaults.standard.string(forKey: "video_quality") ?? "medium"
+    @State private var selectedQuality = UserDefaults.standard.string(forKey: "video_quality") ?? "high"
     @State private var hasAPIKey = false // 改为 State 变量
     @State private var hasGoogleAPIKey = false // Google API Key 状态
 
@@ -242,6 +242,12 @@ struct SettingsView: View {
                             Image(systemName: "chevron.right")
                                 .font(AppTypography.caption)
                                 .foregroundColor(AppColors.textTertiary)
+                        }
+                    }
+
+                    Picker("settings.liveai.model".localized, selection: $providerManager.liveAIModel) {
+                        ForEach(providerManager.liveAIProvider.availableModels, id: \.id) { model in
+                            Text(model.name).tag(model.id)
                         }
                     }
 
@@ -482,7 +488,7 @@ struct APIProviderSettingsView: View {
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text(provider.displayName)
                                         .foregroundColor(.primary)
-                                    Text(provider == .alibaba ? "settings.provider.alibaba.desc".localized : "settings.provider.openrouter.desc".localized)
+                                    Text(providerDescription(provider))
                                         .font(AppTypography.caption)
                                         .foregroundColor(AppColors.textSecondary)
                                 }
@@ -578,6 +584,17 @@ struct APIProviderSettingsView: View {
             }
         }
     }
+
+    private func providerDescription(_ provider: APIProvider) -> String {
+        switch provider {
+        case .alibaba:
+            return "settings.provider.alibaba.desc".localized
+        case .openrouter:
+            return "settings.provider.openrouter.desc".localized
+        case .aihubmix:
+            return "settings.provider.aihubmix.desc".localized
+        }
+    }
 }
 
 // MARK: - API Key Settings
@@ -609,7 +626,7 @@ struct APIKeySettingsView: View {
                     Text("\(displayTitle) API Key")
                 } footer: {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text(provider == .alibaba ? "settings.apikey.alibaba.help".localized : "settings.apikey.openrouter.help".localized)
+                        Text(apiKeyHelpText)
                         Link("settings.apikey.get".localized, destination: URL(string: provider.apiKeyHelpURL)!)
                             .font(.caption)
                     }
@@ -684,6 +701,17 @@ struct APIKeySettingsView: View {
             showError = true
         }
     }
+
+    private var apiKeyHelpText: String {
+        switch provider {
+        case .alibaba:
+            return "settings.apikey.alibaba.help".localized
+        case .openrouter:
+            return "settings.apikey.openrouter.help".localized
+        case .aihubmix:
+            return "settings.apikey.aihubmix.help".localized
+        }
+    }
 }
 
 // MARK: - Vision Model Settings
@@ -699,6 +727,8 @@ struct VisionModelSettingsView: View {
             Group {
                 if providerManager.currentProvider == .alibaba {
                     alibabaModelList
+                } else if providerManager.currentProvider == .aihubmix {
+                    aihubmixModelList
                 } else {
                     openRouterModelList
                 }
@@ -745,6 +775,45 @@ struct VisionModelSettingsView: View {
                 }
             } header: {
                 Text("settings.model.alibaba".localized)
+            } footer: {
+                Text("settings.model.current".localized + ": \(providerManager.selectedModel)")
+            }
+        }
+    }
+
+    private var aihubmixModelList: some View {
+        let models = [
+            ("gpt-5.4", "GPT-5.4", "settings.model.gpt54.desc".localized),
+            ("gpt-5.5", "GPT-5.5", "settings.model.gpt55.desc".localized),
+            ("gemini-3.5-flash", "Gemini 3.5 Flash", "settings.model.gemini35flash.desc".localized),
+            ("gpt-4o-mini", "GPT-4o mini", "settings.model.gpt4omini.desc".localized),
+            ("gpt-4o", "GPT-4o", "settings.model.gpt4o.desc".localized)
+        ]
+
+        return List {
+            Section {
+                ForEach(models, id: \.0) { model in
+                    Button {
+                        providerManager.selectedModel = model.0
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(model.1)
+                                    .foregroundColor(.primary)
+                                Text(model.2)
+                                    .font(AppTypography.caption)
+                                    .foregroundColor(AppColors.textSecondary)
+                            }
+                            Spacer()
+                            if providerManager.selectedModel == model.0 {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("settings.model.aihubmix".localized)
             } footer: {
                 Text("settings.model.current".localized + ": \(providerManager.selectedModel)")
             }

--- a/CameraAccess/en.lproj/Localizable.strings
+++ b/CameraAccess/en.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 "settings.provider.description" = "Choose the API service provider for AI vision";
 "settings.provider.alibaba.desc" = "Alibaba Qwen Vision Models";
 "settings.provider.openrouter.desc" = "Unified API, 500+ AI Models";
+"settings.provider.aihubmix.desc" = "OpenAI-compatible unified model API";
 "settings.provider.getapikey" = "Get API Key";
 
 // Model Settings
@@ -156,8 +157,14 @@
 "settings.model.current" = "Currently using";
 "settings.model.alibaba" = "Alibaba Models";
 "settings.model.openrouter" = "OpenRouter Models";
+"settings.model.aihubmix" = "AIHubMix Models";
 "settings.model.qwen3vlplus.desc" = "High-performance vision model";
 "settings.model.qwen3vlmax.desc" = "Most powerful vision model";
+"settings.model.gpt54.desc" = "AIHubMix GPT-5.4 model";
+"settings.model.gpt55.desc" = "AIHubMix GPT-5.5 model";
+"settings.model.gemini35flash.desc" = "AIHubMix Gemini 3.5 Flash model";
+"settings.model.gpt4omini.desc" = "Default OpenAI-compatible vision model";
+"settings.model.gpt4o.desc" = "Higher quality OpenAI-compatible vision model";
 "settings.model.search" = "Search models...";
 "settings.model.visiononly" = "Show vision-capable models only";
 "settings.model.loading" = "Loading models...";
@@ -173,6 +180,7 @@
 // Live AI Settings
 "settings.liveai" = "Live AI";
 "settings.liveai.provider" = "Live AI Provider";
+"settings.liveai.model" = "Live AI Model";
 "settings.liveai.provider.select" = "Select Live AI Provider";
 "settings.liveai.provider.description" = "Choose the provider for real-time voice chat";
 "settings.liveai.alibaba.desc" = "Qwen Omni real-time audio model";
@@ -197,6 +205,7 @@
 "settings.apikey.placeholder" = "Enter API Key";
 "settings.apikey.alibaba.help" = "Please visit Alibaba Cloud console to get your API Key";
 "settings.apikey.openrouter.help" = "Please visit OpenRouter website to get your API Key";
+"settings.apikey.aihubmix.help" = "Please visit AIHubMix to get your API Key";
 "settings.apikey.google.help" = "Please visit Google AI Studio to get your API Key";
 "settings.apikey.get" = "Get API Key";
 "settings.apikey.delete" = "Delete API Key";
@@ -212,9 +221,9 @@
 "settings.quality.low" = "Low Quality";
 "settings.quality.low.desc" = "Battery saver, for extended use";
 "settings.quality.medium" = "Medium Quality";
-"settings.quality.medium.desc" = "Balanced mode (Recommended)";
+"settings.quality.medium.desc" = "Balanced mode, lower live-stream clarity";
 "settings.quality.high" = "High Quality";
-"settings.quality.high.desc" = "Best quality, higher battery usage";
+"settings.quality.high.desc" = "Best quality, recommended for live streaming";
 "settings.about" = "About";
 "settings.version" = "Version";
 "settings.sdkversion" = "SDK Version";
@@ -249,7 +258,7 @@
 
 // MARK: - AI Prompts
 "prompt.quickvision" = "You are a smart glasses AI assistant. Please describe the image content concisely, suitable for voice announcement.\n\nRequirements:\n1. Describe the main content in 1-2 sentences\n2. Use natural, conversational language\n3. Don't use too many punctuation marks\n4. Keep the total under 50 words\n5. Describe directly, don't say \"in the image\" or \"I see\"";
-"prompt.liveai" = "You are a RayBan Meta smart glasses AI assistant.\n\n[IMPORTANT] Always respond in English.\n\nKeep your answers concise and conversational, like chatting with a friend. The user is wearing glasses and can see their surroundings, provide quick and useful suggestions based on what they see. Be direct and to the point.";
+"prompt.liveai" = "You are a RayBan Meta smart glasses AI assistant.\n\n[IMPORTANT] Support both Chinese and English. Reply in Chinese when the user asks in Chinese, and reply in English when the user asks in English. If the language is unclear, default to English.\n\nKeep your answers concise and conversational, like chatting with a friend. The user is wearing glasses and can see their surroundings, provide quick and useful suggestions based on what they see. Be direct and to the point.";
 
 // MARK: - Quick Vision Modes
 "prompt.quickvision.health" = "Analyze the health aspects of this food/beverage. Provide scientific analysis from these angles:\n1. Nutritional balance\n2. Additives and preservatives\n3. Sugar/salt/fat content\n4. Potential health impacts\n5. Health recommendations\n\nUse concise, conversational language suitable for voice announcement, under 100 words.";
@@ -314,10 +323,10 @@
 "liveai.custom.default" = "You are a helpful assistant. Answer questions concisely.";
 
 // Live AI Mode Prompts
-"prompt.liveai.standard" = "You are a RayBan Meta smart glasses AI assistant.\n\n[IMPORTANT] Always respond in English.\n\nKeep your answers concise and conversational, like chatting with a friend. The user is wearing glasses and can see their surroundings, provide quick and useful suggestions based on what they see. Be direct and to the point.";
-"prompt.liveai.museum" = "You are a professional museum guide AI assistant.\n\n[IMPORTANT] Always respond in English.\n\nWhen the user looks at an exhibit, provide:\n1. Name and basic information\n2. Historical background and cultural significance\n3. Interesting stories or facts\n4. Connections to other exhibits\n\nBe knowledgeable yet engaging, making the visit enjoyable.";
-"prompt.liveai.blind" = "You are a smart glasses assistant for visually impaired users.\n\n[IMPORTANT] Always respond in English.\n\nYour task is to help users understand their surroundings:\n1. Describe objects, people, and environment in detail\n2. Use clear directional words (ahead, left, right rear, etc.)\n3. Point out obstacles or hazards\n4. Read signs, menus, and other text\n5. Provide safe, practical navigation suggestions\n\nSpeak clearly and organized, prioritize the most important information.";
-"prompt.liveai.reading" = "You are a reading assistance AI.\n\n[IMPORTANT] Always respond in English.\n\nYour task is to help users read visible text:\n1. Accurately identify and read all visible text\n2. Organize content in correct reading order\n3. For documents, explain the structure\n4. For foreign languages, read then translate\n\nSpeak at moderate pace, articulate clearly, like a professional reader.";
+"prompt.liveai.standard" = "You are a RayBan Meta smart glasses AI assistant.\n\n[IMPORTANT] Support both Chinese and English. Reply in Chinese when the user asks in Chinese, and reply in English when the user asks in English. If the language is unclear, default to English.\n\nKeep your answers concise and conversational, like chatting with a friend. The user is wearing glasses and can see their surroundings, provide quick and useful suggestions based on what they see. Be direct and to the point.";
+"prompt.liveai.museum" = "You are a professional museum guide AI assistant.\n\n[IMPORTANT] Support both Chinese and English. Reply in Chinese when the user asks in Chinese, and reply in English when the user asks in English. If the language is unclear, default to English.\n\nWhen the user looks at an exhibit, provide:\n1. Name and basic information\n2. Historical background and cultural significance\n3. Interesting stories or facts\n4. Connections to other exhibits\n\nBe knowledgeable yet engaging, making the visit enjoyable.";
+"prompt.liveai.blind" = "You are a smart glasses assistant for visually impaired users.\n\n[IMPORTANT] Support both Chinese and English. Reply in Chinese when the user asks in Chinese, and reply in English when the user asks in English. If the language is unclear, default to English.\n\nYour task is to help users understand their surroundings:\n1. Describe objects, people, and environment in detail\n2. Use clear directional words (ahead, left, right rear, etc.)\n3. Point out obstacles or hazards\n4. Read signs, menus, and other text\n5. Provide safe, practical navigation suggestions\n\nSpeak clearly and organized, prioritize the most important information.";
+"prompt.liveai.reading" = "You are a reading assistance AI.\n\n[IMPORTANT] Support both Chinese and English. Reply in Chinese when the user asks in Chinese, and reply in English when the user asks in English. If the language is unclear, default to English.\n\nYour task is to help users read visible text:\n1. Accurately identify and read all visible text\n2. Organize content in correct reading order\n3. For documents, explain the structure\n4. For foreign languages, read then translate\n\nSpeak at moderate pace, articulate clearly, like a professional reader.";
 "prompt.liveai.translate" = "You are a real-time translation AI assistant.\n\n[IMPORTANT] Translation results must be in {LANGUAGE}.\n\nYour task is to help users understand foreign language content:\n1. Identify text in the view\n2. Translate to {LANGUAGE}\n3. For menus or signs, explain their purpose\n4. For technical terms, provide brief explanations\n\nTranslate accurately, naturally, and idiomatically.";
 
 // MARK: - RTMP Streaming
@@ -344,6 +353,16 @@
 "rtmp.recommended" = "Recommended";
 "rtmp.platform.custom" = "Custom";
 "rtmp.error.invalidurl" = "Please enter a valid RTMP URL";
+"rtmp.error.missingkey" = "Please enter the stream key, or paste a full RTMP URL that includes the stream name";
+"rtmp.error.novideo" = "No glasses video frame received yet. Wait for the preview before starting RTMP.";
+"rtmp.codec.section" = "RTMP Video Codec";
+"rtmp.codec.h264" = "H.264 Compatibility";
+"rtmp.codec.h264.desc" = "Works with most platforms; video may pause when the app enters background";
+"rtmp.codec.hevc" = "HEVC Background Test";
+"rtmp.codec.hevc.desc" = "Uses Meta hvc1 source frames for platforms that support HEVC";
+"rtmp.codec.footer" = "Switching codec restarts the glasses video stream. Use H.264 for normal RTMP platforms; use HEVC to test enhanced RTMP/HEVC platforms.";
+"rtmp.hevc.ready" = "HEVC video stream ready";
+"rtmp.hevc.previewnote" = "HEVC mode uses compressed video frames, so local preview is not shown here. Start streaming to test platform compatibility.";
 
 // MARK: - Live Translate
 "livetranslate.title" = "Live Translate";

--- a/CameraAccess/zh-Hans.lproj/Localizable.strings
+++ b/CameraAccess/zh-Hans.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 "settings.provider.description" = "选择用于 AI 识图的 API 服务提供商";
 "settings.provider.alibaba.desc" = "阿里云通义千问视觉模型";
 "settings.provider.openrouter.desc" = "统一接口，500+ AI 模型";
+"settings.provider.aihubmix.desc" = "OpenAI 兼容的统一模型接口";
 "settings.provider.getapikey" = "获取 API Key";
 
 // Model Settings
@@ -156,8 +157,14 @@
 "settings.model.current" = "当前使用";
 "settings.model.alibaba" = "阿里云模型";
 "settings.model.openrouter" = "OpenRouter 模型";
+"settings.model.aihubmix" = "AIHubMix 模型";
 "settings.model.qwen3vlplus.desc" = "高性能视觉理解模型";
 "settings.model.qwen3vlmax.desc" = "最强视觉理解模型";
+"settings.model.gpt54.desc" = "AIHubMix GPT-5.4 模型";
+"settings.model.gpt55.desc" = "AIHubMix GPT-5.5 模型";
+"settings.model.gemini35flash.desc" = "AIHubMix Gemini 3.5 Flash 模型";
+"settings.model.gpt4omini.desc" = "默认 OpenAI 兼容视觉模型";
+"settings.model.gpt4o.desc" = "更高质量的 OpenAI 兼容视觉模型";
 "settings.model.search" = "搜索模型...";
 "settings.model.visiononly" = "仅显示支持视觉的模型";
 "settings.model.loading" = "加载模型列表...";
@@ -173,6 +180,7 @@
 // Live AI Settings
 "settings.liveai" = "Live AI";
 "settings.liveai.provider" = "Live AI 提供商";
+"settings.liveai.model" = "Live AI 模型";
 "settings.liveai.provider.select" = "选择 Live AI 提供商";
 "settings.liveai.provider.description" = "选择用于实时语音对话的 AI 提供商";
 "settings.liveai.alibaba.desc" = "通义千问 Omni 实时音频模型";
@@ -197,6 +205,7 @@
 "settings.apikey.placeholder" = "请输入 API Key";
 "settings.apikey.alibaba.help" = "请前往阿里云控制台获取您的 API Key";
 "settings.apikey.openrouter.help" = "请前往 OpenRouter 网站获取您的 API Key";
+"settings.apikey.aihubmix.help" = "请前往 AIHubMix 获取您的 API Key";
 "settings.apikey.google.help" = "请前往 Google AI Studio 获取您的 API Key";
 "settings.apikey.get" = "获取 API Key";
 "settings.apikey.delete" = "删除 API Key";
@@ -212,9 +221,9 @@
 "settings.quality.low" = "低画质";
 "settings.quality.low.desc" = "省电模式，适合长时间使用";
 "settings.quality.medium" = "中画质";
-"settings.quality.medium.desc" = "平衡模式（推荐）";
+"settings.quality.medium.desc" = "平衡模式，直播清晰度较低";
 "settings.quality.high" = "高画质";
-"settings.quality.high.desc" = "最佳画质，耗电较快";
+"settings.quality.high.desc" = "最佳画质，直播推荐，耗电较快";
 "settings.about" = "关于";
 "settings.version" = "版本";
 "settings.sdkversion" = "SDK 版本";
@@ -249,7 +258,7 @@
 
 // MARK: - AI Prompts
 "prompt.quickvision" = "你是一个智能眼镜AI助手。请用简洁的中文描述图片内容，适合语音播报。\n\n要求：\n1. 用1-2句话描述主要内容\n2. 语言自然、口语化\n3. 不要使用标点符号过多\n4. 总字数控制在50字以内\n5. 直接描述，不要说\"图片中\"或\"我看到\"";
-"prompt.liveai" = "你是RayBan Meta智能眼镜AI助手。\n\n【重要】必须始终用中文回答，无论用户说什么语言。\n\n回答要简练、口语化，像朋友聊天一样。用户戴着眼镜可以看到周围环境，根据画面快速给出有用的建议。不要啰嗦，直接说重点。";
+"prompt.liveai" = "你是RayBan Meta智能眼镜AI助手。\n\n【重要】支持中文和英文。用户用中文提问就用中文回答，用户用英文提问就用英文回答；如果语言不明确，默认用中文。\n\n回答要简练、口语化，像朋友聊天一样。用户戴着眼镜可以看到周围环境，根据画面快速给出有用的建议。不要啰嗦，直接说重点。";
 
 // MARK: - Quick Vision Modes
 "prompt.quickvision.health" = "分析这个食品/饮料的健康程度。从以下角度科学分析：\n1. 营养成分是否均衡\n2. 添加剂和防腐剂情况\n3. 糖分/盐分/脂肪含量\n4. 对身体的潜在影响\n5. 给出健康建议\n\n用简洁口语化的方式回答，适合语音播报，控制在100字以内。";
@@ -314,10 +323,10 @@
 "liveai.custom.default" = "你是一个智能助手，帮助用户完成各种任务。请用简洁的语言回答问题。";
 
 // Live AI Mode Prompts
-"prompt.liveai.standard" = "你是RayBan Meta智能眼镜AI助手。\n\n【重要】必须始终用中文回答，无论用户说什么语言。\n\n回答要简练、口语化，像朋友聊天一样。用户戴着眼镜可以看到周围环境，根据画面快速给出有用的建议。不要啰嗦，直接说重点。";
-"prompt.liveai.museum" = "你是一位专业的博物馆讲解员AI助手。\n\n【重要】必须始终用中文回答。\n\n当用户看向展品时，请提供：\n1. 展品名称和基本信息\n2. 历史背景和文化意义\n3. 有趣的故事或知识点\n4. 与其他展品的关联\n\n像一位知识渊博又风趣的讲解员，让参观变得生动有趣。";
-"prompt.liveai.blind" = "你是视障用户的智能眼镜助手。\n\n【重要】必须始终用中文回答。\n\n你的任务是帮助用户理解周围环境：\n1. 详细描述周围的物体、人和环境\n2. 使用清晰的方位词（前方、左侧、右后方等）\n3. 指出可能的障碍物或危险\n4. 朗读标识、菜单等文字内容\n5. 提供安全、实用的导航建议\n\n说话清晰、有条理，优先说最重要的信息。";
-"prompt.liveai.reading" = "你是阅读辅助AI助手。\n\n【重要】必须始终用中文回答。\n\n你的任务是帮助用户阅读看到的文字：\n1. 准确识别并朗读所有可见文字\n2. 按照正确的阅读顺序组织内容\n3. 对于文档，说明文字的结构\n4. 对于外语，先读原文再翻译\n\n语速适中，吐字清晰，像一位专业的朗读者。";
+"prompt.liveai.standard" = "你是RayBan Meta智能眼镜AI助手。\n\n【重要】支持中文和英文。用户用中文提问就用中文回答，用户用英文提问就用英文回答；如果语言不明确，默认用中文。\n\n回答要简练、口语化，像朋友聊天一样。用户戴着眼镜可以看到周围环境，根据画面快速给出有用的建议。不要啰嗦，直接说重点。";
+"prompt.liveai.museum" = "你是一位专业的博物馆讲解员AI助手。\n\n【重要】支持中文和英文。用户用中文提问就用中文回答，用户用英文提问就用英文回答；如果语言不明确，默认用中文。\n\n当用户看向展品时，请提供：\n1. 展品名称和基本信息\n2. 历史背景和文化意义\n3. 有趣的故事或知识点\n4. 与其他展品的关联\n\n像一位知识渊博又风趣的讲解员，让参观变得生动有趣。";
+"prompt.liveai.blind" = "你是视障用户的智能眼镜助手。\n\n【重要】支持中文和英文。用户用中文提问就用中文回答，用户用英文提问就用英文回答；如果语言不明确，默认用中文。\n\n你的任务是帮助用户理解周围环境：\n1. 详细描述周围的物体、人和环境\n2. 使用清晰的方位词（前方、左侧、右后方等）\n3. 指出可能的障碍物或危险\n4. 朗读标识、菜单等文字内容\n5. 提供安全、实用的导航建议\n\n说话清晰、有条理，优先说最重要的信息。";
+"prompt.liveai.reading" = "你是阅读辅助AI助手。\n\n【重要】支持中文和英文。用户用中文提问就用中文回答，用户用英文提问就用英文回答；如果语言不明确，默认用中文。\n\n你的任务是帮助用户阅读看到的文字：\n1. 准确识别并朗读所有可见文字\n2. 按照正确的阅读顺序组织内容\n3. 对于文档，说明文字的结构\n4. 对于外语，先读原文再翻译\n\n语速适中，吐字清晰，像一位专业的朗读者。";
 "prompt.liveai.translate" = "你是实时翻译AI助手。\n\n【重要】翻译结果必须使用{LANGUAGE}。\n\n你的任务是帮助用户理解看到的外语内容：\n1. 识别画面中的文字\n2. 翻译成{LANGUAGE}\n3. 如果是菜单或标识，说明其用途\n4. 对于专业术语，提供简单解释\n\n翻译要准确、自然、地道。";
 
 // MARK: - RTMP 推流
@@ -344,6 +353,16 @@
 "rtmp.recommended" = "推荐";
 "rtmp.platform.custom" = "自定义";
 "rtmp.error.invalidurl" = "请输入有效的 RTMP 地址";
+"rtmp.error.missingkey" = "请输入推流密钥，或粘贴包含流名称的完整 RTMP 推流地址";
+"rtmp.error.novideo" = "还没有收到眼镜视频画面，请等待画面出现后再开始推流";
+"rtmp.codec.section" = "RTMP 编码模式";
+"rtmp.codec.h264" = "H.264 兼容模式";
+"rtmp.codec.h264.desc" = "兼容大多数平台，App 进入后台后视频容易暂停";
+"rtmp.codec.hevc" = "HEVC 后台实验模式";
+"rtmp.codec.hevc.desc" = "使用 Meta hvc1 原始视频流，适合测试支持 HEVC 的平台";
+"rtmp.codec.footer" = "切换编码模式会重启眼镜视频流。H.264 适合普通 RTMP 平台；HEVC 用于测试支持增强 RTMP/HEVC 的平台。";
+"rtmp.hevc.ready" = "HEVC 视频流已就绪";
+"rtmp.hevc.previewnote" = "HEVC 模式使用压缩视频帧，当前不显示本地预览；可以直接开始推流测试平台兼容性。";
 
 // MARK: - Live Translate 实时翻译
 "livetranslate.title" = "实时翻译";


### PR DESCRIPTION
## Summary
- add AIHubMix as a vision/chat API provider with API key, model, and localization support
- update Live AI for Gemini Live model selection, bilingual replies, continuous visual frame context, and clearer connection errors
- fix Live Translate provider/key separation so realtime translation stays on Alibaba DashScope
- improve RTMP full URL handling, audio capture, quality/bitrate controls, stream stats, and H.264/HEVC mode selection

## Validation
- Built for physical iPhone with xcodebuild using local build-time Meta credentials only
- Installed and launched on the connected iPhone via devicectl
- Scanned staged diff for Meta AppID, ClientToken, local Team ID, and provided secrets before commit; no matches found

## Notes
- This PR intentionally does not commit META_APP_ID or CLIENT_TOKEN. Those remain build-time values supplied locally.